### PR TITLE
fix: restore Cyprus SST, branding, and image-send idempotency

### DIFF
--- a/cyprus_image_recovery.py
+++ b/cyprus_image_recovery.py
@@ -21,6 +21,7 @@ from visual_context_cy import parse_visual_context_cy
 
 LOCAL_WEATHER_CARD_VERSION = "cy_local_atmospheric_visual_v2"
 LOCAL_INFORMATIVE_COVER_VERSION = "cy_local_informative_cover_v3"
+LOCAL_INFORMATIVE_COVER_BRANDING = "VAYBOMETER · CYPRUS WEATHER BRIEF"
 PROVIDER_HEALTH_SCHEMA_VERSION = 1
 _PROVIDER_NAMES = ("pollinations", "stable_horde", "custom")
 _INVALID_ERROR_CATEGORIES = {
@@ -869,11 +870,12 @@ def render_local_informative_cover(
         raise ValueError(f"invalid Cyprus informative-cover post type: {post_type!r}")
     ctx, facts = _informative_cover_facts(final_text, post_type=mode)
     palette, top, bottom, accent = _cover_palette(ctx)
-    rendered_lines = [facts["headline"]]
+    rendered_lines = [LOCAL_INFORMATIVE_COVER_BRANDING, facts["headline"]]
     rendered_lines.extend(value for key, value in facts.items() if key != "headline" and value)
-    rendered_text = "\n".join(rendered_lines[:4])
+    rendered_text = "\n".join(rendered_lines[:5])
     cache_payload = {
         "renderer_version": LOCAL_INFORMATIVE_COVER_VERSION,
+        "branding": LOCAL_INFORMATIVE_COVER_BRANDING,
         "target_date": safe_date,
         "post_type": mode,
         "visual_forecast_period": ctx.visual_forecast_period,
@@ -902,7 +904,20 @@ def render_local_informative_cover(
     title_font = _cover_font(74, bold=True)
     small_font = _cover_font(28, bold=False)
     draw.text((100, 105), facts["headline"], font=title_font, fill=(*accent, 255))
-    draw.text((102, 205), "VAYBOMETER · WEATHER BRIEF", font=small_font, fill=(*accent, 175))
+    branding_origin = (102, 205)
+    branding_bbox = list(
+        draw.textbbox(
+            branding_origin,
+            LOCAL_INFORMATIVE_COVER_BRANDING,
+            font=small_font,
+        )
+    )
+    draw.text(
+        branding_origin,
+        LOCAL_INFORMATIVE_COVER_BRANDING,
+        font=small_font,
+        fill=(*accent, 175),
+    )
     fact_values = [facts["primary_fact"], facts["secondary_fact"], facts["tertiary_fact"]]
     fact_layout = _draw_cover_fact_cards(
         draw,
@@ -917,6 +932,8 @@ def render_local_informative_cover(
         "backend": "local_informative_cover",
         "generator_version": LOCAL_INFORMATIVE_COVER_VERSION,
         "renderer_version": LOCAL_INFORMATIVE_COVER_VERSION,
+        "branding": LOCAL_INFORMATIVE_COVER_BRANDING,
+        "branding_bbox": json.dumps(branding_bbox, separators=(",", ":")),
         "target_date": safe_date,
         "post_type": mode,
         "visual_forecast_period": ctx.visual_forecast_period,
@@ -976,6 +993,7 @@ def render_local_weather_card(
 __all__ = [
     "LOCAL_WEATHER_CARD_VERSION",
     "LOCAL_INFORMATIVE_COVER_VERSION",
+    "LOCAL_INFORMATIVE_COVER_BRANDING",
     "load_provider_health",
     "mark_provider_duplicate",
     "provider_health_exclusions",

--- a/post_common.py
+++ b/post_common.py
@@ -17,7 +17,7 @@ post_common.py — VayboMeter (Кипр/универсальный).
 from __future__ import annotations
 import os, re, json, html, asyncio, logging, math, datetime as dt, random, imghdr
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Optional, Union
+from typing import Any, Dict, List, Tuple, Optional, Sequence, Union
 
 import pendulum
 from telegram import Bot, constants
@@ -1818,6 +1818,20 @@ def _city_detail_line(
     return float(tmax), " • ".join(parts)
 
 
+def _morning_sea_city_lines(
+    sea_pairs: Sequence[tuple[str, tuple[float, float]]],
+    tz_obj: pendulum.Timezone,
+) -> List[str]:
+    """Build morning coastal rows through the canonical city formatter with SST."""
+
+    rows: List[str] = []
+    for city, (la, lo) in sea_pairs:
+        _tmax, line = _city_detail_line(city, la, lo, tz_obj, include_sst=True)
+        if line:
+            rows.append(line)
+    return rows
+
+
 def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone) -> Optional[str]:
     wm = get_weather(la, lo) or {}
     wind_ms, wind_dir, _, _ = pick_tomorrow_header_metrics(wm, tz_obj)
@@ -2138,6 +2152,10 @@ def build_message(
         uv_line = _uv_warning_line_for_morning(wm_region, tz_obj)
         if uv_line:
             P.append(uv_line)
+
+        sea_rows_morning = _morning_sea_city_lines(sea_pairs, tz_obj)
+        if sea_rows_morning:
+            P.extend(sea_rows_morning)
 
         la_sun, lo_sun = _choose_sun_coords(sea_pairs, other_pairs)
         sun_line = sun_line_for_mode(mode, tz_obj, la_sun, lo_sun)

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -342,6 +342,7 @@ def cy_morning_image_phase_for_result(image_result: str) -> str:
         "failed_after_duplicates": "image_failed_non_fatal",
         "skipped": "image_skipped",
         "skipped_receipt_exists": "image_skipped",
+        "skipped_receipt_appeared_during_generation": "image_skipped",
         "skipped_no_text_receipt": "image_skipped",
         "skipped_duplicate": "image_skipped",
         "skipped_duplicate_before_send": "image_skipped",
@@ -2624,6 +2625,33 @@ async def _build_safe_test_image(
                         "backend": selected_backend,
                         **_generation_summary("skipped_duplicate_before_send", selected_backend),
                     }
+            if production_image_send and is_valid_cy_image_receipt(metadata["forecast_date"], mode):
+                receipt_path = _cy_image_receipt_path(metadata["forecast_date"], mode)
+                print(f"CY_SAFE_IMAGE_RECEIPT_APPEARED_DURING_GENERATION: {receipt_path}")
+                _cy_write_image_diagnostics(
+                    mode=mode,
+                    target_date=metadata["forecast_date"],
+                    result="skipped_receipt_appeared_during_generation",
+                    prompt_metadata=metadata,
+                    attempts=attempts,
+                    telegram_attempts=telegram_attempts,
+                    write_history_path=write_history_path,
+                    reference_history_paths=reference_history_paths,
+                    history_count_before=before_history_count,
+                    generation_summary=_generation_summary(
+                        "skipped_receipt_appeared_during_generation",
+                        selected_backend,
+                    ),
+                )
+                return {
+                    "result": "skipped_receipt_appeared_during_generation",
+                    "message_ids": [],
+                    "backend": selected_backend,
+                    **_generation_summary(
+                        "skipped_receipt_appeared_during_generation",
+                        selected_backend,
+                    ),
+                }
             image_bot = Bot(token=TOKEN)
             image_caption = _cy_image_caption(
                 mode,

--- a/tools/test_cyprus_image_fallback.py
+++ b/tools/test_cyprus_image_fallback.py
@@ -38,6 +38,7 @@ from PIL import Image, ImageDraw  # type: ignore  # noqa: E402
 import cyprus_visual_dedup  # noqa: E402
 import cyprus_image_recovery  # noqa: E402
 from cyprus_image_recovery import (  # noqa: E402
+    LOCAL_INFORMATIVE_COVER_BRANDING,
     LOCAL_INFORMATIVE_COVER_VERSION,
     load_provider_health,
     mark_provider_duplicate,
@@ -121,6 +122,44 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _write_valid_image_receipt(
+    target_date: str,
+    post_type: str,
+    *,
+    message_id: int = 7001,
+) -> Path:
+    path = safe_module._cy_image_receipt_path(target_date, post_type)
+    safe_module._cy_write_json_atomic(
+        path,
+        {
+            "target_date": target_date,
+            "post_type": post_type,
+            "chat_type": "production",
+            "telegram_message_id": message_id,
+            "sha256": "a" * 64,
+            "selected_scene": "fixture_scene",
+            "sent_at_utc": "2026-07-15T18:00:00Z",
+        },
+    )
+    return path
+
+
+def _write_valid_text_receipt(target_date: str, post_type: str) -> Path:
+    path = safe_module._cy_text_receipt_path(target_date, post_type)
+    safe_module._cy_write_json_atomic(
+        path,
+        {
+            "target_date": target_date,
+            "post_type": post_type,
+            "chat_type": "production",
+            "telegram_message_ids": [6001],
+            "text_chunk_count": 1,
+            "sent_at_utc": "2026-07-15T17:59:00Z",
+        },
+    )
+    return path
+
+
 def local_informative_cover_is_valid_deterministic_and_factual() -> None:
     with tempfile.TemporaryDirectory() as tmp_name:
         tmp = Path(tmp_name)
@@ -154,6 +193,8 @@ def local_informative_cover_is_valid_deterministic_and_factual() -> None:
         assert _sha256(first_path) != _sha256(evening_path)
         required_metadata = {
             "renderer_version",
+            "branding",
+            "branding_bbox",
             "visual_forecast_period",
             "primary_weather",
             "hazards",
@@ -173,6 +214,13 @@ def local_informative_cover_is_valid_deterministic_and_factual() -> None:
         assert required_metadata <= set(evening["metadata"])
         assert first["metadata"]["renderer_version"] == LOCAL_INFORMATIVE_COVER_VERSION
         assert evening["metadata"]["renderer_version"] == LOCAL_INFORMATIVE_COVER_VERSION
+        assert first["metadata"]["branding"] == LOCAL_INFORMATIVE_COVER_BRANDING
+        assert first["metadata"]["rendered_text"].splitlines()[0] == LOCAL_INFORMATIVE_COVER_BRANDING
+        brand_left, brand_top, brand_right, brand_bottom = json.loads(
+            first["metadata"]["branding_bbox"]
+        )
+        assert 92 <= brand_left < brand_right <= 988
+        assert 80 <= brand_top < brand_bottom <= 300
         assert evening["metadata"]["headline"] == "КИПР ЗАВТРА"
         assert evening["metadata"]["primary_fact"] == "🔥 ДО 38° В НИКОСИИ"
         assert evening["metadata"]["secondary_fact"] == "💨 ПОРЫВЫ ДО 15 М/С У МОРЯ"
@@ -201,6 +249,8 @@ def local_informative_cover_is_valid_deterministic_and_factual() -> None:
             assert image.info["target_date"] == "2026-07-15"
             assert image.info["post_type"] == "morning"
             assert image.info["headline"] == "КИПР СЕГОДНЯ"
+            assert image.info["branding"] == LOCAL_INFORMATIVE_COVER_BRANDING
+            assert image.info["branding_bbox"] == first["metadata"]["branding_bbox"]
             assert image.info["rendered_text"]
             image.verify()
         with Image.open(evening_path) as image:
@@ -708,6 +758,204 @@ def primary_evening_incident_sends_local_visual_before_text() -> None:
         asyncio.run(run_case(Path(tmp_name)))
 
 
+def image_receipt_recheck_closes_primary_and_recovery_send_race() -> None:
+    async def run_case(
+        case_dir: Path,
+        *,
+        receipt_during_generation: bool = False,
+        existing_receipt: str = "",
+        send_to_test: bool = False,
+        image_only_recovery: bool = False,
+    ) -> tuple[dict[str, object], list[dict[str, object]], dict[str, object]]:
+        history_prod = case_dir / "history-prod.json"
+        history_test = case_dir / "history-test.json"
+        history_prod.parent.mkdir(parents=True, exist_ok=True)
+        history_prod.write_text("[]", encoding="utf-8")
+        history_test.write_text("[]", encoding="utf-8")
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH = history_prod
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH = history_test
+
+        os.environ.update(
+            {
+                "CHANNEL_ID": "777",
+                "CHANNEL_ID_TEST": "778",
+                "CY_SAFE_IMAGE_DIR": str(case_dir / "images"),
+                "CY_IMG_MIN_BYTES": "12000",
+                "CY_IMAGE_DELIVERY_DIR": str(case_dir / "image-receipts"),
+                "CY_TEXT_DELIVERY_DIR": str(case_dir / "text-receipts"),
+                "CY_IMAGE_DIAGNOSTICS_DIR": str(case_dir / "diagnostics"),
+                "CY_IMAGE_PROVIDER_HEALTH_DIR": str(case_dir / "provider-health"),
+            }
+        )
+
+        if existing_receipt == "valid":
+            _write_valid_image_receipt("2026-07-16", "evening")
+        elif existing_receipt == "invalid":
+            safe_module._cy_write_json_atomic(
+                safe_module._cy_image_receipt_path("2026-07-16", "evening"),
+                {
+                    "target_date": "2026-07-15",
+                    "post_type": "evening",
+                    "chat_type": "production",
+                    "telegram_message_id": 0,
+                    "sent_at_utc": "",
+                },
+            )
+        if image_only_recovery:
+            _write_valid_text_receipt("2026-07-16", "evening")
+
+        photo_calls: list[dict[str, object]] = []
+
+        def successful_outcome(_prompt: str, requested_path: str, **_kwargs):
+            if receipt_during_generation:
+                _write_valid_image_receipt("2026-07-16", "evening", message_id=7002)
+            path = Path(requested_path)
+            _write_dhash_fixture(path, flipped_rows=2)
+            backend_attempts = [
+                {
+                    "backend": "pollinations",
+                    "result": "success",
+                    "http_status": 200,
+                    "content_type": "image/jpeg",
+                    "payload_byte_count": path.stat().st_size,
+                }
+            ]
+            generated = types.SimpleNamespace(
+                path=str(path),
+                backend="pollinations",
+                byte_count=path.stat().st_size,
+                backend_attempts=backend_attempts,
+            )
+            return types.SimpleNamespace(
+                result=generated,
+                backend_attempts=backend_attempts,
+                error_type="",
+                error_message="",
+                exhausted=False,
+                actual_backend_call_count=1,
+            )
+
+        class FakeBot:
+            def __init__(self, token: str) -> None:
+                assert token == "fixture-token"
+
+            async def send_photo(self, **kwargs):
+                photo_calls.append(
+                    {
+                        "chat_id": kwargs["chat_id"],
+                        "caption": kwargs["caption"],
+                        "photo_bytes": kwargs["photo"].read(),
+                    }
+                )
+                return types.SimpleNamespace(message_id=9101)
+
+        safe_module.Bot = FakeBot
+        imagegen.generate_astro_image_outcome_with_exclusions = successful_outcome
+        imagegen.configured_image_backends = lambda **_kwargs: {
+            "configured_backends": ["pollinations"],
+            "available_backends": ["pollinations"],
+            "unconfigured_backends": ["stable_horde", "custom"],
+        }
+
+        result = await safe_module._build_safe_test_image(
+            EVENING_MESSAGE,
+            "evening",
+            generate_image=True,
+            send_image_to_test=send_to_test,
+            send_image_to_chat=not send_to_test,
+            image_chat_id=None if send_to_test else 777,
+            image_only_recovery=image_only_recovery,
+        )
+        diagnostics = json.loads(
+            (
+                case_dir
+                / "diagnostics"
+                / "2026-07-16-evening"
+                / "image_result.json"
+            ).read_text(encoding="utf-8")
+        )
+        return result, photo_calls, diagnostics
+
+    env_names = (
+        "CHANNEL_ID",
+        "CHANNEL_ID_TEST",
+        "CY_SAFE_IMAGE_DIR",
+        "CY_IMG_MIN_BYTES",
+        "CY_IMAGE_DELIVERY_DIR",
+        "CY_TEXT_DELIVERY_DIR",
+        "CY_IMAGE_DIAGNOSTICS_DIR",
+        "CY_IMAGE_PROVIDER_HEALTH_DIR",
+    )
+    old_env = {name: os.environ.get(name) for name in env_names}
+    old_token = safe_module.TOKEN
+    old_bot = safe_module.Bot
+    old_outcome = imagegen.generate_astro_image_outcome_with_exclusions
+    old_availability = imagegen.configured_image_backends
+    old_prod_history = cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH
+    old_test_history = cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH
+    safe_module.TOKEN = "fixture-token"
+    try:
+        with tempfile.TemporaryDirectory() as tmp_name:
+            root = Path(tmp_name)
+
+            primary_race, primary_photos, primary_diag = asyncio.run(
+                run_case(root / "primary-race", receipt_during_generation=True)
+            )
+            assert primary_race["result"] == "skipped_receipt_appeared_during_generation"
+            assert primary_photos == []
+            assert primary_diag["image_result"] == "skipped_receipt_appeared_during_generation"
+            assert primary_diag["selected_backend"] == "pollinations"
+
+            ordinary, ordinary_photos, ordinary_diag = asyncio.run(
+                run_case(root / "ordinary")
+            )
+            assert ordinary["result"] == "sent"
+            assert len(ordinary_photos) == 1
+            assert ordinary_diag["image_result"] == "sent"
+            assert safe_module.is_valid_cy_image_receipt("2026-07-16", "evening")
+
+            test_send, test_photos, test_diag = asyncio.run(
+                run_case(root / "test-send", existing_receipt="valid", send_to_test=True)
+            )
+            assert test_send["result"] == "sent"
+            assert len(test_photos) == 1 and test_photos[0]["chat_id"] == 778
+            assert test_diag["image_result"] == "sent"
+
+            stale, stale_photos, stale_diag = asyncio.run(
+                run_case(root / "stale-receipt", existing_receipt="invalid")
+            )
+            assert stale["result"] == "sent"
+            assert len(stale_photos) == 1
+            assert stale_diag["image_result"] == "sent"
+            assert safe_module.is_valid_cy_image_receipt("2026-07-16", "evening")
+
+            recovery_race, recovery_photos, recovery_diag = asyncio.run(
+                run_case(
+                    root / "recovery-race",
+                    receipt_during_generation=True,
+                    image_only_recovery=True,
+                )
+            )
+            assert recovery_race["result"] == "skipped_receipt_appeared_during_generation"
+            assert recovery_photos == []
+            assert recovery_diag["image_result"] == "skipped_receipt_appeared_during_generation"
+            assert safe_module.cy_morning_image_phase_for_result(
+                recovery_race["result"]
+            ) == "image_skipped"
+    finally:
+        safe_module.TOKEN = old_token
+        safe_module.Bot = old_bot
+        imagegen.generate_astro_image_outcome_with_exclusions = old_outcome
+        imagegen.configured_image_backends = old_availability
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH = old_prod_history
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH = old_test_history
+        for name, value in old_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 def informative_cover_failure_falls_through_to_text_without_stale_image() -> None:
     async def run_case(tmp: Path) -> None:
         env_names = (
@@ -840,6 +1088,7 @@ def main() -> None:
         local_cover_graphics_and_cache_follow_confirmed_facts,
         provider_health_is_date_and_namespace_scoped,
         primary_evening_incident_sends_local_visual_before_text,
+        image_receipt_recheck_closes_primary_and_recovery_send_race,
         informative_cover_failure_falls_through_to_text_without_stale_image,
     )
     for check in checks:

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -31,9 +31,10 @@ imghdr_stub = types.ModuleType("imghdr")
 imghdr_stub.what = lambda *args, **kwargs: None
 sys.modules.setdefault("imghdr", imghdr_stub)
 
-from format_v2 import build_format_v2, build_morning_format_v2  # noqa: E402
+from format_v2 import build_evening_format_v2, build_format_v2, build_morning_format_v2  # noqa: E402
 import cyprus_visual_dedup  # noqa: E402
 import image_prompt_cy_scene as cy_scene_prompt  # noqa: E402
+import post_common as post_common_module  # noqa: E402
 import safe_test_post as safe_module  # noqa: E402
 import weather as weather_module  # noqa: E402
 from image_prompt_cy_scene import build_cyprus_scene_prompt_with_metadata  # noqa: E402
@@ -303,6 +304,60 @@ def cy_morning_adds_concise_sea_block_when_available() -> None:
     assert "🏭 Воздух: AQI 58 (умеренный) • PM₂.₅ 14 / PM₁₀ 31 • 🌿 пыльца: низкая" in text
     assert "📟" not in text
     assert "🌿 пыльца" in text
+
+
+def cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening() -> None:
+    calls: list[tuple[str, float, float, bool]] = []
+    old_city_detail_line = post_common_module._city_detail_line
+
+    def fake_city_detail_line(city, la, lo, _tz_obj, include_sst):
+        calls.append((city, la, lo, include_sst))
+        temperatures = {"Лимассол": 26.0, "Ларнака": 28.0}
+        sst = temperatures[city]
+        return 34.0, f"<b>{city}</b>: 34/25 °C • ясно • 🌊 {sst:.0f}"
+
+    pairs = [
+        ("Лимассол", (34.68, 33.04)),
+        ("Ларнака", (34.92, 33.63)),
+    ]
+    try:
+        post_common_module._city_detail_line = fake_city_detail_line
+        rows = post_common_module._morning_sea_city_lines(
+            pairs,
+            types.SimpleNamespace(name="Asia/Nicosia"),
+        )
+        assert [line.split(":", 1)[0] for line in rows] == ["<b>Лимассол</b>", "<b>Ларнака</b>"]
+        assert calls == [
+            ("Лимассол", 34.68, 33.04, True),
+            ("Ларнака", 34.92, 33.63, True),
+        ]
+
+        raw_morning = MORNING_NO_SEA.replace(
+            "✅ Сегодня:",
+            "\n".join(rows) + "\n✅ Сегодня:",
+        )
+        morning = build_morning_format_v2("Кипр", raw_morning)
+        assert "🌊 Море: средняя вода 27°C;" in morning
+
+        raw_evening = """<b>Кипр: погода на завтра (28.06.2026)</b>
+🏖 <b>Морские города</b>
+{rows}
+———
+✅ Завтра: море утром.
+#Кипр #погода
+""".format(rows="\n".join(rows))
+        evening = build_evening_format_v2("Кипр", raw_evening)
+        assert evening.index("<b>Лимассол</b>") < evening.index("<b>Ларнака</b>")
+
+        post_common_module._city_detail_line = lambda *_args, **_kwargs: (None, None)
+        assert post_common_module._morning_sea_city_lines(
+            pairs,
+            types.SimpleNamespace(name="Asia/Nicosia"),
+        ) == []
+        fallback = build_morning_format_v2("Кипр", MORNING_NO_SEA)
+        assert "данные о температуре воды обновляются" in fallback
+    finally:
+        post_common_module._city_detail_line = old_city_detail_line
 
 
 def cy_morning_averages_coastal_sea_rows() -> None:
@@ -1961,6 +2016,7 @@ def cy_morning_safe_production_polish_keeps_fog_actions() -> None:
 def main() -> None:
     checks = (
         cy_morning_adds_concise_sea_block_when_available,
+        cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening,
         cy_morning_averages_coastal_sea_rows,
         cy_morning_adds_sea_fallback_when_unavailable,
         cy_morning_rejects_non_marine_numbers_for_sea,


### PR DESCRIPTION
## Summary

- Restores real coastal SST rows to the Cyprus morning legacy message through the existing `_city_detail_line(..., include_sst=True)` path, so FORMAT_V2 uses measured values and retains its unavailable-data fallback.
- Restores `VAYBOMETER · CYPRUS WEATHER BRIEF` on the deterministic informative v3 cover and records the branding/bounds in PNG metadata.
- Rechecks the production image delivery receipt immediately before Telegram `send_photo`, closing the TOCTOU window for both primary posting and image-only recovery.

The 20.07 duplicate's historical root cause cannot be proven without the original logs. The receipt race itself is real and is covered by deterministic offline regression tests.

## Validation

- 15 offline scripts, 263 checks passed.
- Morning/evening FORMAT_V2, image fallback, visual dedup/workflow, image validation, air, earthquakes, editorial, FX, weekly, monthly, visual, and model migration checks passed.
- Receipt-race coverage includes primary, recovery, ordinary send, test-channel isolation, and stale/invalid receipt behavior.
- Actual informative cover rendered at 1080×1080; branding bbox is inside the safe card and fact cards remain intact.
- `python -m compileall -q .`, changed-file `py_compile`, 13 workflow YAML parses, and `git diff --check` passed.

No workflows, Safecast data, secrets, binaries, generated images, or caches are included.