### PR TITLE
fix: reject unrelated Cyprus provider images

### DIFF
--- a/tools/test_cyprus_image_content_guard.py
+++ b/tools/test_cyprus_image_content_guard.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Regression checks for the Cyprus provider-image content guard."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from PIL import Image, ImageDraw  # type: ignore  # noqa: E402
+import world_en.imagegen as imagegen  # noqa: E402
+from world_en import image_content_guard as guard  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, content: bytes, content_type: str = "image/png") -> None:
+        self.content = content
+        self.headers = {"Content-Type": content_type}
+        self.status_code = 200
+
+
+def _image_bytes(builder) -> bytes:
+    image = Image.new("RGB", (512, 512), (135, 175, 190))
+    builder(image)
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _screen_like_bytes() -> bytes:
+    def build(image: Image.Image) -> None:
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((0, 0, 511, 40), fill=(70, 115, 145))
+        x = 8
+        for index in range(28):
+            width = 3 + index % 5
+            draw.rectangle(
+                (x, 9 + index % 3, x + width, 17 + index % 4),
+                fill=(25, 55, 75),
+            )
+            x += 16 + index % 4
+            if x > 500:
+                break
+        draw.line((0, 39, 511, 39), fill=(210, 225, 230), width=2)
+        draw.ellipse((50, 60, 430, 490), fill=(218, 232, 224))
+        for index in range(8):
+            draw.ellipse(
+                (300 + index * 10, 90 + index * 40, 335 + index * 12, 125 + index * 40),
+                fill=(70, 120, 140),
+            )
+        draw.line((80, 350, 350, 260), fill=(240, 120, 150), width=2)
+
+    return _image_bytes(build)
+
+
+def _landscape_bytes() -> bytes:
+    def build(image: Image.Image) -> None:
+        draw = ImageDraw.Draw(image)
+        for y in range(280):
+            draw.line((0, y, 511, y), fill=(135 + y // 5, 185 + y // 8, 220 + y // 15))
+        draw.rectangle((0, 280, 511, 400), fill=(45, 135, 180))
+        draw.polygon([(0, 390), (512, 360), (512, 512), (0, 512)], fill=(225, 195, 145))
+        for x in range(0, 512, 30):
+            draw.line((x, 320, x + 20, 315), fill=(210, 230, 235), width=2)
+        draw.ellipse((80, 80, 250, 135), fill=(225, 235, 240))
+
+    return _image_bytes(build)
+
+
+def _set_env(name: str, value: str | None):
+    previous = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    return previous
+
+
+def _restore_env(name: str, previous: str | None) -> None:
+    if previous is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = previous
+
+
+def guard_is_installed_on_imagegen_validator() -> None:
+    assert getattr(imagegen._validate_generated_image, "_cyprus_content_guard_installed", False)
+
+
+def screen_like_provider_image_is_rejected_and_removed() -> None:
+    previous_guard = _set_env("CY_IMAGE_CONTENT_GUARD", "1")
+    previous_min = _set_env("IMAGEGEN_MIN_VALID_BYTES", "128")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_name:
+            out_path = Path(tmp_name) / "screen.png"
+            result = imagegen._validate_generated_image(
+                backend="pollinations",
+                out_path=out_path,
+                payload=_screen_like_bytes(),
+                status_code=200,
+                content_type="image/png",
+            )
+            assert result is None
+            assert not out_path.exists()
+            imagegen._set_backend_diagnostics("pollinations", {"error_category": "invalid_image"})
+            diagnostics = imagegen._take_backend_diagnostics("pollinations")
+            assert diagnostics["error_category"] == "semantic_mismatch"
+            assert diagnostics["content_guard"]["reason"] == "screen_or_ui_chrome"
+            assert diagnostics["content_guard"]["valid"] is False
+    finally:
+        _restore_env("CY_IMAGE_CONTENT_GUARD", previous_guard)
+        _restore_env("IMAGEGEN_MIN_VALID_BYTES", previous_min)
+
+
+def ordinary_landscape_provider_image_is_accepted() -> None:
+    previous_guard = _set_env("CY_IMAGE_CONTENT_GUARD", "1")
+    previous_min = _set_env("IMAGEGEN_MIN_VALID_BYTES", "128")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_name:
+            out_path = Path(tmp_name) / "landscape.png"
+            result = imagegen._validate_generated_image(
+                backend="pollinations",
+                out_path=out_path,
+                payload=_landscape_bytes(),
+                status_code=200,
+                content_type="image/png",
+            )
+            assert result is not None
+            assert out_path.exists()
+            imagegen._set_backend_diagnostics("pollinations", {})
+            diagnostics = imagegen._take_backend_diagnostics("pollinations")
+            assert diagnostics["content_guard"]["valid"] is True
+            assert diagnostics["content_guard"]["reason"] == "accepted"
+    finally:
+        _restore_env("CY_IMAGE_CONTENT_GUARD", previous_guard)
+        _restore_env("IMAGEGEN_MIN_VALID_BYTES", previous_min)
+
+
+def explicit_kill_switch_preserves_technical_validation() -> None:
+    previous_guard = _set_env("CY_IMAGE_CONTENT_GUARD", "0")
+    previous_min = _set_env("IMAGEGEN_MIN_VALID_BYTES", "128")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_name:
+            out_path = Path(tmp_name) / "screen-disabled.png"
+            result = imagegen._validate_generated_image(
+                backend="pollinations",
+                out_path=out_path,
+                payload=_screen_like_bytes(),
+                status_code=200,
+                content_type="image/png",
+            )
+            assert result is not None
+            assert out_path.exists()
+    finally:
+        _restore_env("CY_IMAGE_CONTENT_GUARD", previous_guard)
+        _restore_env("IMAGEGEN_MIN_VALID_BYTES", previous_min)
+
+
+def rejected_pollinations_image_falls_back_to_horde() -> None:
+    previous_guard = _set_env("CY_IMAGE_CONTENT_GUARD", "1")
+    previous_min = _set_env("IMAGEGEN_MIN_VALID_BYTES", "128")
+    old_get = imagegen.requests.get
+    old_horde = imagegen._fetch_from_horde
+    old_attempts = imagegen.MAX_ATTEMPTS
+    old_custom_url = imagegen.CUSTOM_IMAGE_BASE_URL
+    horde_calls: list[str] = []
+
+    def fake_get(*_args, **_kwargs):
+        return FakeResponse(_screen_like_bytes())
+
+    def fake_horde(_prompt: str, out_path: Path, **_kwargs):
+        horde_calls.append(str(out_path))
+        payload = _landscape_bytes()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(payload)
+        return imagegen.ImageGenerationResult(
+            path=str(out_path),
+            backend="stable_horde",
+            byte_count=len(payload),
+            content_type="image/png",
+        )
+
+    try:
+        imagegen.requests.get = fake_get
+        imagegen._fetch_from_horde = fake_horde
+        imagegen.MAX_ATTEMPTS = 1
+        imagegen.CUSTOM_IMAGE_BASE_URL = ""
+        with tempfile.TemporaryDirectory() as tmp_name:
+            out_path = Path(tmp_name) / "candidate.png"
+            outcome = imagegen.generate_astro_image_outcome(
+                "Cyprus coast and forecast sky",
+                str(out_path),
+                max_backend_calls=2,
+            )
+            assert outcome.result is not None
+            assert outcome.result.backend == "stable_horde"
+            assert len(horde_calls) == 1
+            assert len(outcome.backend_attempts) == 2
+            rejected = outcome.backend_attempts[0]
+            assert rejected["backend"] == "pollinations"
+            assert rejected["result"] == "failed"
+            assert rejected["error_category"] == "semantic_mismatch"
+            assert rejected["content_guard"]["reason"] == "screen_or_ui_chrome"
+    finally:
+        imagegen.requests.get = old_get
+        imagegen._fetch_from_horde = old_horde
+        imagegen.MAX_ATTEMPTS = old_attempts
+        imagegen.CUSTOM_IMAGE_BASE_URL = old_custom_url
+        _restore_env("CY_IMAGE_CONTENT_GUARD", previous_guard)
+        _restore_env("IMAGEGEN_MIN_VALID_BYTES", previous_min)
+
+
+def incident_fingerprints_are_pinned() -> None:
+    assert guard._INCIDENT_DHASH == "0f1f560b0f150b03"
+    assert guard._INCIDENT_PHASH == "d0692ba536263f36"
+    assert guard._hamming_hex(guard._INCIDENT_DHASH, "0f1f560b0f150b03") == 0
+    assert guard._hamming_hex(guard._INCIDENT_PHASH, "d0692ba536263f36") == 0
+
+
+def main() -> None:
+    checks = (
+        guard_is_installed_on_imagegen_validator,
+        screen_like_provider_image_is_rejected_and_removed,
+        ordinary_landscape_provider_image_is_accepted,
+        explicit_kill_switch_preserves_technical_validation,
+        rejected_pollinations_image_falls_back_to_horde,
+        incident_fingerprints_are_pinned,
+    )
+    for check in checks:
+        check()
+        print(f"PASS: {check.__name__}")
+    print(f"OK: {len(checks)} Cyprus image content guard checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/world_en/__init__.py
+++ b/world_en/__init__.py
@@ -1,1 +1,9 @@
+"""World image-generation package hooks."""
 
+from . import imagegen as _imagegen
+from .image_content_guard import install_imagegen_guard as _install_imagegen_guard
+
+_install_imagegen_guard(_imagegen)
+
+del _imagegen
+del _install_imagegen_guard

--- a/world_en/image_content_guard.py
+++ b/world_en/image_content_guard.py
@@ -1,0 +1,292 @@
+"""Local semantic guard for Cyprus provider-generated images.
+
+The upstream providers occasionally return a technically valid but unrelated
+image. This module adds a conservative, offline gate before such an image can
+be accepted by ``world_en.imagegen``. It deliberately targets only high
+confidence failures:
+
+* the known 2026-07-31 incident image (and very close perceptual variants);
+* screenshots / photographs of screens with a dense UI chrome band.
+
+The local informative cover does not pass through ``world_en.imagegen`` and is
+therefore unaffected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from functools import wraps
+import logging
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    from PIL import Image, ImageFilter, ImageOps
+except Exception:  # pragma: no cover - imagegen already rejects without Pillow
+    Image = None  # type: ignore
+    ImageFilter = None  # type: ignore
+    ImageOps = None  # type: ignore
+
+
+LOG = logging.getLogger("imagegen.content_guard")
+
+# Production incident: 2026-07-31, unrelated screen / medical-scan-like image.
+# We keep only perceptual fingerprints, never the user image itself.
+_INCIDENT_DHASH = "0f1f560b0f150b03"
+_INCIDENT_PHASH = "d0692ba536263f36"
+_INCIDENT_DHASH_MAX_DISTANCE = 6
+_INCIDENT_PHASH_MAX_DISTANCE = 10
+
+_SAMPLE_SIZE = 256
+_EDGE_THRESHOLD = 45
+_TOP_START_ROW = 2
+_TOP_END_ROW = 32
+_BODY_START_ROW = 48
+_BODY_END_ROW = 254
+
+
+@dataclass(frozen=True)
+class ImageContentVerdict:
+    valid: bool
+    reason: str
+    dhash: str
+    phash: str
+    incident_dhash_distance: int | None
+    incident_phash_distance: int | None
+    top_edge_density: float
+    body_edge_density: float
+    top_to_body_edge_ratio: float
+    dense_top_rows: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _env_truthy(name: str, default: str = "") -> bool:
+    return str(os.getenv(name, default)).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def content_guard_enabled() -> bool:
+    """Enable explicitly, or implicitly for the Cyprus image workflow."""
+    explicit = os.getenv("CY_IMAGE_CONTENT_GUARD")
+    if explicit is not None:
+        return _env_truthy("CY_IMAGE_CONTENT_GUARD")
+    return _env_truthy("CY_IMG_ENABLED")
+
+
+def _hamming_hex(left: str, right: str) -> int | None:
+    try:
+        return (int(left, 16) ^ int(right, 16)).bit_count()
+    except Exception:
+        return None
+
+
+def _dhash(image: "Image.Image", *, hash_size: int = 8) -> str:
+    gray = ImageOps.grayscale(image).resize(
+        (hash_size + 1, hash_size),
+        Image.Resampling.LANCZOS,
+    )
+    values = list(gray.getdata())
+    bits: list[str] = []
+    for y in range(hash_size):
+        row = y * (hash_size + 1)
+        for x in range(hash_size):
+            bits.append("1" if values[row + x] > values[row + x + 1] else "0")
+    return f"{int(''.join(bits), 2):0{hash_size * hash_size // 4}x}"
+
+
+def _phash(image: "Image.Image", *, size: int = 32, low: int = 8) -> str:
+    gray = ImageOps.grayscale(image).resize((size, size), Image.Resampling.LANCZOS)
+    values = [float(value) for value in gray.getdata()]
+    cos_x = [
+        [math.cos(((2 * x + 1) * u * math.pi) / (2 * size)) for x in range(size)]
+        for u in range(low)
+    ]
+    cos_y = [
+        [math.cos(((2 * y + 1) * v * math.pi) / (2 * size)) for y in range(size)]
+        for v in range(low)
+    ]
+    coeffs: list[float] = []
+    for v in range(low):
+        for u in range(low):
+            total = 0.0
+            for y in range(size):
+                row = y * size
+                cy = cos_y[v][y]
+                total += sum(values[row + x] * cos_x[u][x] * cy for x in range(size))
+            coeffs.append(total)
+    comparable = coeffs[1:]
+    median = sorted(comparable)[len(comparable) // 2] if comparable else 0.0
+    bits = ["1" if value > median else "0" for value in coeffs]
+    return f"{int(''.join(bits), 2):0{low * low // 4}x}"
+
+
+def _edge_metrics(image: "Image.Image") -> tuple[float, float, float, int]:
+    sample = ImageOps.grayscale(
+        image.convert("RGB").resize(
+            (_SAMPLE_SIZE, _SAMPLE_SIZE),
+            Image.Resampling.LANCZOS,
+        )
+    )
+    edges = sample.filter(ImageFilter.FIND_EDGES)
+    values = list(edges.getdata())
+    rows: list[float] = []
+    for y in range(_SAMPLE_SIZE):
+        start = y * _SAMPLE_SIZE
+        row = values[start : start + _SAMPLE_SIZE]
+        rows.append(sum(value >= _EDGE_THRESHOLD for value in row) / _SAMPLE_SIZE)
+
+    top_rows = rows[_TOP_START_ROW:_TOP_END_ROW]
+    body_rows = rows[_BODY_START_ROW:_BODY_END_ROW]
+    top = sum(top_rows) / len(top_rows)
+    body = sum(body_rows) / len(body_rows)
+    ratio = top / max(body, 1e-6)
+    dense_top_rows = sum(value >= 0.20 for value in top_rows)
+    return top, body, ratio, dense_top_rows
+
+
+def inspect_provider_image(path: str | Path) -> ImageContentVerdict:
+    if Image is None:
+        return ImageContentVerdict(
+            valid=False,
+            reason="pillow_unavailable",
+            dhash="",
+            phash="",
+            incident_dhash_distance=None,
+            incident_phash_distance=None,
+            top_edge_density=0.0,
+            body_edge_density=0.0,
+            top_to_body_edge_ratio=0.0,
+            dense_top_rows=0,
+        )
+
+    with Image.open(path) as opened:
+        image = opened.convert("RGB")
+        dhash = _dhash(image)
+        incident_dhash_distance = _hamming_hex(dhash, _INCIDENT_DHASH)
+        phash = _phash(image)
+        incident_phash_distance = _hamming_hex(phash, _INCIDENT_PHASH)
+        top, body, ratio, dense_top_rows = _edge_metrics(image)
+
+    known_incident = (
+        incident_dhash_distance is not None
+        and incident_phash_distance is not None
+        and incident_dhash_distance <= _INCIDENT_DHASH_MAX_DISTANCE
+        and incident_phash_distance <= _INCIDENT_PHASH_MAX_DISTANCE
+    )
+    screenshot_chrome = (
+        top >= 0.11
+        and body <= 0.08
+        and ratio >= 3.0
+        and dense_top_rows >= 6
+    )
+
+    if known_incident:
+        reason = "known_unrelated_incident"
+    elif screenshot_chrome:
+        reason = "screen_or_ui_chrome"
+    else:
+        reason = "accepted"
+
+    return ImageContentVerdict(
+        valid=reason == "accepted",
+        reason=reason,
+        dhash=dhash,
+        phash=phash,
+        incident_dhash_distance=incident_dhash_distance,
+        incident_phash_distance=incident_phash_distance,
+        top_edge_density=round(top, 6),
+        body_edge_density=round(body, 6),
+        top_to_body_edge_ratio=round(ratio, 6),
+        dense_top_rows=dense_top_rows,
+    )
+
+
+def install_imagegen_guard(imagegen_module: Any) -> None:
+    """Patch the technical validator once, keeping provider retry semantics."""
+    original_validate = getattr(imagegen_module, "_validate_generated_image", None)
+    original_set_diagnostics = getattr(imagegen_module, "_set_backend_diagnostics", None)
+    if not callable(original_validate) or not callable(original_set_diagnostics):
+        raise RuntimeError("world_en.imagegen validation hooks are unavailable")
+    if getattr(original_validate, "_cyprus_content_guard_installed", False):
+        return
+
+    pending: dict[str, dict[str, Any]] = {}
+
+    @wraps(original_set_diagnostics)
+    def guarded_set_diagnostics(backend: str, payload: dict[str, Any]) -> None:
+        merged = dict(payload)
+        guard_payload = pending.pop(str(backend), None)
+        if guard_payload:
+            merged["content_guard"] = guard_payload
+            if not guard_payload.get("valid"):
+                merged["error_category"] = "semantic_mismatch"
+                merged["error_message"] = (
+                    "provider image rejected by Cyprus content guard: "
+                    + str(guard_payload.get("reason") or "unknown")
+                )
+        original_set_diagnostics(backend, merged)
+
+    @wraps(original_validate)
+    def guarded_validate(
+        *,
+        backend: str,
+        out_path: Path,
+        payload: bytes,
+        status_code: int | None = None,
+        content_type: str | None = None,
+    ):
+        result = original_validate(
+            backend=backend,
+            out_path=out_path,
+            payload=payload,
+            status_code=status_code,
+            content_type=content_type,
+        )
+        if result is None or not content_guard_enabled():
+            return result
+
+        try:
+            verdict = inspect_provider_image(out_path)
+        except Exception as exc:
+            # Fail closed for Cyprus production: a broken relevance gate must
+            # trigger the normal provider/fallback ladder, never a blind send.
+            verdict = ImageContentVerdict(
+                valid=False,
+                reason=f"content_guard_error:{exc.__class__.__name__}",
+                dhash="",
+                phash="",
+                incident_dhash_distance=None,
+                incident_phash_distance=None,
+                top_edge_density=0.0,
+                body_edge_density=0.0,
+                top_to_body_edge_ratio=0.0,
+                dense_top_rows=0,
+            )
+
+        pending[str(backend)] = verdict.to_dict()
+        if verdict.valid:
+            return result
+
+        try:
+            Path(out_path).unlink(missing_ok=True)
+        except Exception:
+            pass
+        LOG.warning(
+            "%s provider image rejected before publication: reason=%s "
+            "dhash=%s phash=%s top_edge=%.4f body_edge=%.4f ratio=%.2f",
+            backend,
+            verdict.reason,
+            verdict.dhash,
+            verdict.phash,
+            verdict.top_edge_density,
+            verdict.body_edge_density,
+            verdict.top_to_body_edge_ratio,
+        )
+        return None
+
+    guarded_validate._cyprus_content_guard_installed = True  # type: ignore[attr-defined]
+    imagegen_module._set_backend_diagnostics = guarded_set_diagnostics
+    imagegen_module._validate_generated_image = guarded_validate


### PR DESCRIPTION
## Incident

On 2026-07-31 the Cyprus VayboMeter published a technically valid 512×512 image that was unrelated to Cyprus or weather and looked like a photograph of a screen / medical scan.

The existing image validator checked MIME type, file signature, byte count, Pillow decode, dimensions, the known Pollinations rate-limit placeholder, and visual duplication. It did not reject semantically unrelated screen/UI imagery.

## Change

- Add a conservative offline content guard for provider-generated Cyprus images.
- Reject the exact incident image and close perceptual variants using pinned dHash+pHash fingerprints; the user image itself is not committed.
- Reject high-confidence screenshots / photographs of screens using a dense top UI-chrome edge pattern with a low-detail body.
- Activate the guard only when `CY_IMAGE_CONTENT_GUARD=1` or the existing Cyprus flag `CY_IMG_ENABLED=1` is active.
- Fail closed: a rejected image is deleted and returned as an invalid provider result, so the existing provider/fallback ladder continues instead of sending it.
- Merge structured `content_guard` diagnostics into backend diagnostics without secrets.
- Preserve an explicit kill switch: `CY_IMAGE_CONTENT_GUARD=0`.

## Regression coverage

`tools/test_cyprus_image_content_guard.py` checks:

1. the guard is installed on `world_en.imagegen`;
2. a synthetic screen/medical-like provider image is rejected and removed;
3. a synthetic Cyprus-style landscape remains accepted;
4. the explicit kill switch preserves technical-only validation;
5. rejected Pollinations output falls through to Stable Horde;
6. the production incident fingerprints remain pinned.

No Telegram calls, provider calls, workflow changes, data files, secrets, or generated images are included.