### PR TITLE
fix: explain Cyprus ruble moves in plain Russian

### DIFF
--- a/post_cy_fx_market_pulse.py
+++ b/post_cy_fx_market_pulse.py
@@ -32,12 +32,52 @@ from post_cy import (
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
+_CURRENCY_NAMES_RU = {
+    "EUR": "евро",
+    "USD": "доллар",
+}
+_CURRENCY_ORDER = ("EUR", "USD")
+
 
 def _to_float(x: Any) -> float | None:
     try:
         return float(x)
     except Exception:
         return None
+
+
+def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
+    """Explain EUR/USD moves against RUB without repeating the numbers above."""
+    parts: list[str] = []
+    for code in _CURRENCY_ORDER:
+        delta = _to_float((rates.get(code) or {}).get("delta"))
+        if delta is None:
+            continue
+        name = _CURRENCY_NAMES_RU[code]
+        if abs(delta) < 0.005:
+            parts.append(f"{name} почти не изменился")
+        elif delta > 0:
+            parts.append(f"{name} подорожал")
+        else:
+            parts.append(f"{name} подешевел")
+    if not parts:
+        return ""
+    return "🧭 К рублю: " + ", ".join(parts) + "."
+
+
+def replace_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
+    """Replace trading-style RUB commentary with a short everyday explanation."""
+    summary = build_plain_ruble_summary(rates)
+    if not summary:
+        return fx_text
+    lines = str(fx_text or "").splitlines()
+    for index, line in enumerate(lines):
+        if line.strip().startswith("🧭"):
+            lines[index] = summary
+            break
+    else:
+        lines.append(summary)
+    return "\n".join(lines)
 
 
 def _fmt_usd_compact(value: float | None) -> str:
@@ -242,6 +282,7 @@ async def main() -> None:
     fx_cache_path, inter_cache_path = _fx_cache_paths(args.to_test)
 
     fx_text, rates, inter_today = _build_fx_message_eur(date_local, tz, inter_cache_path)
+    fx_text = replace_ruble_summary(fx_text, rates)
     text = inject_market_pulse(fx_text, build_market_pulse_block())
     raw_date = rates.get("as_of") or rates.get("date") or rates.get("cbr_date")
     cbr_date = _normalize_cbr_date(raw_date)

--- a/tools/test_fx_market_pulse_cy.py
+++ b/tools/test_fx_market_pulse_cy.py
@@ -37,7 +37,7 @@ class _Date:
         return "2026-06-27"
 
 
-def _build_fx_text_with_ruble_deltas(eur_delta: float, usd_delta: float) -> str:
+def _build_fx_text_with_ruble_deltas(eur_delta: float, usd_delta: float) -> tuple[str, dict]:
     post_cy._fetch_intermarket_eur_with_prev = lambda _today, _path: (
         {"USD": 1.14, "GBP": 0.86, "TRY": 53.14, "ILS": 3.41},
         {"USD": 1.14, "GBP": 0.86, "TRY": 52.96, "ILS": 3.39},
@@ -52,34 +52,45 @@ def _build_fx_text_with_ruble_deltas(eur_delta: float, usd_delta: float) -> str:
         "EUR": {"value": 87.40, "delta": eur_delta},
         "USD": {"value": 77.06, "delta": usd_delta},
     }
-    text, _rates, _inter = post_cy._build_fx_message_eur(_Date(), None, Path("unused.json"))
-    return text
+    text, rates, _inter = post_cy._build_fx_message_eur(_Date(), None, Path("unused.json"))
+    return text, rates
 
 
-def cy_fx_message_hides_ecb_when_intermarket_exists(tmp_path: Path | None = None) -> None:
-    text = _build_fx_text_with_ruble_deltas(1.63, 1.43)
+def cy_fx_numeric_lines_stay_unchanged() -> None:
+    text, _rates = _build_fx_text_with_ruble_deltas(1.63, -1.43)
     assert "💱 <b>Курсы валют | 1 EUR</b>" in text
     assert "ECB official:" not in text
     assert "EUR: USD 1.14 · GBP 0.86 · TRY 53.14 ↑0.18 · ILS 3.41 ↑0.02" in text
-    assert "К ₽: EUR 87.40 ↑1.63 · USD 77.06 ↑1.43" in text
-    assert "🧭 € и $ к ₽ выше; для поездок по региону смотрим TRY/ILS." in text
+    assert "К ₽: EUR 87.40 ↑1.63 · USD 77.06 ↓1.43" in text
     assert "#Кипр #курсы_валют #рынки" in text
-    assert "EUR/USD к рублю выше" not in text
 
 
-def cy_fx_summary_positive_is_higher() -> None:
-    text = _build_fx_text_with_ruble_deltas(1.63, 1.43)
-    assert "🧭 € и $ к ₽ выше; для поездок по региону смотрим TRY/ILS." in text
+def cy_plain_summary_explains_mixed_moves_without_repeating_numbers() -> None:
+    raw, rates = _build_fx_text_with_ruble_deltas(1.63, -1.43)
+    text = pulse.replace_ruble_summary(raw, rates)
+    assert "🧭 К рублю: евро подорожал, доллар подешевел." in text
+    assert "Рублёвые пары смешанно" not in text
+    assert "для поездок по региону смотрим TRY/ILS" not in text
+    summary = pulse.build_plain_ruble_summary(rates)
+    assert "1.63" not in summary and "1.43" not in summary
 
 
-def cy_fx_summary_negative_is_lower() -> None:
-    text = _build_fx_text_with_ruble_deltas(-1.63, -1.43)
-    assert "🧭 € и $ к ₽ ниже; для поездок по региону смотрим TRY/ILS." in text
+def cy_plain_summary_handles_both_up() -> None:
+    _raw, rates = _build_fx_text_with_ruble_deltas(1.63, 1.43)
+    assert pulse.build_plain_ruble_summary(rates) == "🧭 К рублю: евро подорожал, доллар подорожал."
 
 
-def cy_fx_summary_mixed_is_mixed() -> None:
-    text = _build_fx_text_with_ruble_deltas(1.63, -1.43)
-    assert "🧭 Рублёвые пары смешанно; для поездок по региону смотрим TRY/ILS." in text
+def cy_plain_summary_handles_both_down() -> None:
+    _raw, rates = _build_fx_text_with_ruble_deltas(-1.63, -1.43)
+    assert pulse.build_plain_ruble_summary(rates) == "🧭 К рублю: евро подешевел, доллар подешевел."
+
+
+def cy_plain_summary_handles_zero_and_missing() -> None:
+    rates = {
+        "EUR": {"value": 87.40, "delta": 0.0},
+        "USD": {"value": 77.06, "delta": None},
+    }
+    assert pulse.build_plain_ruble_summary(rates) == "🧭 К рублю: евро почти не изменился."
 
 
 def cy_market_pulse_is_compact() -> None:
@@ -106,10 +117,11 @@ def cy_fx_market_hashtag_survives_empty_or_existing_pulse() -> None:
 
 def main() -> None:
     checks = (
-        cy_fx_message_hides_ecb_when_intermarket_exists,
-        cy_fx_summary_positive_is_higher,
-        cy_fx_summary_negative_is_lower,
-        cy_fx_summary_mixed_is_mixed,
+        cy_fx_numeric_lines_stay_unchanged,
+        cy_plain_summary_explains_mixed_moves_without_repeating_numbers,
+        cy_plain_summary_handles_both_up,
+        cy_plain_summary_handles_both_down,
+        cy_plain_summary_handles_zero_and_missing,
         cy_market_pulse_is_compact,
         cy_fx_market_hashtag_survives_empty_or_existing_pulse,
     )


### PR DESCRIPTION
## Problem

The published Cyprus FX summary used trading-style wording such as `Рублёвые пары смешанно; для поездок по региону смотрим TRY/ILS`, which is harder to understand than the numeric lines above.

## Change

- keep the existing numeric EUR-base and RUB lines unchanged;
- replace only the public explanatory `🧭` line in the separate daytime FX + Market Pulse runner;
- use plain Russian: `евро подорожал`, `доллар подешевел`, `почти не изменился`;
- do not repeat numeric deltas because they are already shown above;
- remove the redundant TRY/ILS travel commentary because TRY and ILS are already visible in the EUR line;
- add focused offline tests for mixed/up/down/flat/missing-data cases.

Example:

`🧭 К рублю: евро подорожал, доллар подешевел.`

No workflows, Telegram calls, external market requests, data files or secrets are changed.