### PR TITLE
fix: skip Cyprus RUB summary when CBR values are absent

### DIFF
--- a/post_cy_fx_market_pulse.py
+++ b/post_cy_fx_market_pulse.py
@@ -65,6 +65,10 @@ def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
     return "🧭 К рублю: " + ", ".join(parts) + "."
 
 
+def _has_current_ruble_value(rates: dict[str, Any]) -> bool:
+    return any(_to_float((rates.get(code) or {}).get("value")) is not None for code in _CURRENCY_ORDER)
+
+
 def replace_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
     """Replace trading-style RUB commentary with a short everyday explanation."""
     summary = build_plain_ruble_summary(rates)
@@ -73,9 +77,10 @@ def replace_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
     for index, line in enumerate(lines):
         if line.strip().startswith("🧭"):
             lines[index] = replacement
-            break
-    else:
-        lines.append(replacement)
+            return "\n".join(lines)
+    if not _has_current_ruble_value(rates):
+        return fx_text
+    lines.append(replacement)
     return "\n".join(lines)
 
 

--- a/tools/test_fx_market_pulse_cy.py
+++ b/tools/test_fx_market_pulse_cy.py
@@ -109,6 +109,22 @@ def cy_safe_runner_uses_same_summary_formatter() -> None:
     assert "🧭 К рублю: евро подорожал, доллар подешевел." in text
 
 
+def cy_no_cbr_values_do_not_append_ruble_summary_after_hashtags() -> None:
+    raw = (
+        "💱 <b>Курсы валют | 1 EUR</b>\n"
+        "EUR: USD 1.14 · GBP 0.86 · TRY 53.14 · ILS 3.41\n\n"
+        "#Кипр #курсы_валют #рынки"
+    )
+    rates = {
+        "EUR": {"value": None, "delta": None},
+        "USD": {"value": None, "delta": None},
+    }
+    text = pulse.replace_ruble_summary(raw, rates)
+    assert text == raw
+    assert "🧭 К рублю:" not in text
+    assert text.rstrip().endswith("#Кипр #курсы_валют #рынки")
+
+
 def cy_market_pulse_is_compact() -> None:
     pulse._fetch_crypto = lambda: ["24ч: BTC $60.3K ↑1.2% · ETH $1.6K ↑2.0%"]
     pulse._fetch_gold = lambda: ["Gold/oz $4.1K"]
@@ -140,6 +156,7 @@ def main() -> None:
         cy_plain_summary_handles_zero_and_missing,
         cy_missing_deltas_never_restore_old_jargon,
         cy_safe_runner_uses_same_summary_formatter,
+        cy_no_cbr_values_do_not_append_ruble_summary_after_hashtags,
         cy_market_pulse_is_compact,
         cy_fx_market_hashtag_survives_empty_or_existing_pulse,
     )


### PR DESCRIPTION
## Follow-up to PR #25

Codex found one final partial-data edge case: when CBR returns neither a current EUR nor USD value, there is no RUB section to summarize and no `🧭` line should be appended after the hashtags.

## Fix

- replace an existing `🧭` line when present;
- append a plain RUB summary/fallback only when at least one current EUR/USD RUB value exists;
- leave the FX text untouched when CBR has no current RUB values at all;
- add a focused regression test proving no RUB summary appears after hashtags in that case.

No workflows, Telegram calls, external market requests, data files or secrets are changed.