### PR TITLE
feat: explain Cyprus EUR moves in plain Russian

### DIFF
--- a/post_cy_fx_market_pulse.py
+++ b/post_cy_fx_market_pulse.py
@@ -13,7 +13,6 @@ import importlib
 import json
 import logging
 import os
-import re
 from typing import Any
 
 import pendulum
@@ -46,7 +45,6 @@ _EUR_QUOTE_FORMS = {
     "ILS": ("шекель", "подорожал", "подешевел", "почти не изменился"),
 }
 _EUR_QUOTE_ORDER = ("USD", "GBP", "TRY", "ILS")
-_EUR_SEGMENT_RE = re.compile(r"^(USD|GBP|TRY|ILS)\s+[^↑↓]+?(?:\s*([↑↓]))?$")
 
 
 def _to_float(x: Any) -> float | None:
@@ -94,10 +92,12 @@ def build_plain_eur_summary(fx_text: str) -> str:
     any_arrow = False
     for raw in segments:
         segment = raw.strip()
-        match = _EUR_SEGMENT_RE.match(segment)
-        if not match:
+        if not segment:
             continue
-        code, arrow = match.group(1), match.group(2)
+        code = segment.split(None, 1)[0]
+        if code not in _EUR_QUOTE_FORMS:
+            continue
+        arrow = "↑" if "↑" in segment else "↓" if "↓" in segment else None
         parsed[code] = arrow
         any_arrow = any_arrow or bool(arrow)
 

--- a/post_cy_fx_market_pulse.py
+++ b/post_cy_fx_market_pulse.py
@@ -13,6 +13,7 @@ import importlib
 import json
 import logging
 import os
+import re
 from typing import Any
 
 import pendulum
@@ -37,6 +38,15 @@ _CURRENCY_NAMES_RU = {
     "USD": "доллар",
 }
 _CURRENCY_ORDER = ("EUR", "USD")
+
+_EUR_QUOTE_FORMS = {
+    "USD": ("доллар", "подорожал", "подешевел", "почти не изменился"),
+    "GBP": ("фунт", "подорожал", "подешевел", "почти не изменился"),
+    "TRY": ("турецкая лира", "подорожала", "подешевела", "почти не изменилась"),
+    "ILS": ("шекель", "подорожал", "подешевел", "почти не изменился"),
+}
+_EUR_QUOTE_ORDER = ("USD", "GBP", "TRY", "ILS")
+_EUR_SEGMENT_RE = re.compile(r"^(USD|GBP|TRY|ILS)\s+[^↑↓]+?(?:\s*([↑↓]))?$")
 
 
 def _to_float(x: Any) -> float | None:
@@ -65,22 +75,95 @@ def build_plain_ruble_summary(rates: dict[str, Any]) -> str:
     return "🧭 К рублю: " + ", ".join(parts) + "."
 
 
+def build_plain_eur_summary(fx_text: str) -> str:
+    """Explain quote-currency moves vs EUR from the already displayed EUR line.
+
+    The displayed pair is units of quote currency per 1 EUR. Therefore an upward
+    arrow means EUR buys more quote currency and that quote currency weakened
+    against EUR; a downward arrow means it strengthened against EUR.
+    """
+    lines = str(fx_text or "").splitlines()
+    source_line = next((line.strip() for line in lines if line.strip().startswith("EUR:")), "")
+    if not source_line:
+        source_line = next((line.strip() for line in lines if line.strip().startswith("ECB official:")), "")
+    if not source_line or ":" not in source_line:
+        return ""
+
+    segments = source_line.split(":", 1)[1].split("·")
+    parsed: dict[str, str | None] = {}
+    any_arrow = False
+    for raw in segments:
+        segment = raw.strip()
+        match = _EUR_SEGMENT_RE.match(segment)
+        if not match:
+            continue
+        code, arrow = match.group(1), match.group(2)
+        parsed[code] = arrow
+        any_arrow = any_arrow or bool(arrow)
+
+    if not parsed:
+        return ""
+    if not any_arrow:
+        return "🧭 К евро: динамика за день пока недоступна."
+
+    parts: list[str] = []
+    for code in _EUR_QUOTE_ORDER:
+        if code not in parsed:
+            continue
+        name, stronger, weaker, flat = _EUR_QUOTE_FORMS[code]
+        arrow = parsed[code]
+        if arrow == "↑":
+            parts.append(f"{name} {weaker}")
+        elif arrow == "↓":
+            parts.append(f"{name} {stronger}")
+        else:
+            parts.append(f"{name} {flat}")
+    return "🧭 К евро: " + ", ".join(parts) + "." if parts else ""
+
+
 def _has_current_ruble_value(rates: dict[str, Any]) -> bool:
     return any(_to_float((rates.get(code) or {}).get("value")) is not None for code in _CURRENCY_ORDER)
 
 
+def _is_ruble_summary_line(line: str) -> bool:
+    text = line.strip()
+    return (
+        text.startswith("🧭 К рублю:")
+        or text.startswith("🧭 € и $ к ₽")
+        or text.startswith("🧭 Рублёвые пары")
+    )
+
+
 def replace_ruble_summary(fx_text: str, rates: dict[str, Any]) -> str:
-    """Replace trading-style RUB commentary with a short everyday explanation."""
+    """Add the EUR explanation and replace RUB jargon with plain Russian."""
+    lines = str(fx_text or "").splitlines()
+
+    eur_summary = build_plain_eur_summary(fx_text)
+    if eur_summary:
+        existing_eur = next((i for i, line in enumerate(lines) if line.strip().startswith("🧭 К евро:")), None)
+        if existing_eur is not None:
+            lines[existing_eur] = eur_summary
+        else:
+            source_index = next(
+                (i for i, line in enumerate(lines) if line.strip().startswith("EUR:")),
+                next((i for i, line in enumerate(lines) if line.strip().startswith("ECB official:")), None),
+            )
+            if source_index is not None:
+                lines.insert(source_index + 1, eur_summary)
+
     summary = build_plain_ruble_summary(rates)
     replacement = summary or "🧭 К рублю: динамика за день пока недоступна."
-    lines = str(fx_text or "").splitlines()
     for index, line in enumerate(lines):
-        if line.strip().startswith("🧭"):
+        if _is_ruble_summary_line(line):
             lines[index] = replacement
             return "\n".join(lines)
+
     if not _has_current_ruble_value(rates):
-        return fx_text
-    lines.append(replacement)
+        return "\n".join(lines)
+
+    cbr_index = next((i for i, line in enumerate(lines) if line.strip().startswith("К ₽:")), None)
+    if cbr_index is not None:
+        lines.insert(cbr_index + 1, replacement)
     return "\n".join(lines)
 
 

--- a/tools/test_fx_market_pulse_cy.py
+++ b/tools/test_fx_market_pulse_cy.py
@@ -66,7 +66,52 @@ def cy_fx_numeric_lines_stay_unchanged() -> None:
     assert "#Кипр #курсы_валют #рынки" in text
 
 
-def cy_plain_summary_explains_mixed_moves_without_repeating_numbers() -> None:
+def cy_plain_eur_summary_explains_displayed_moves() -> None:
+    raw, rates = _build_fx_text_with_ruble_deltas(1.63, -1.43)
+    text = pulse.replace_ruble_summary(raw, rates)
+    expected = (
+        "🧭 К евро: доллар почти не изменился, фунт почти не изменился, "
+        "турецкая лира подешевела, шекель подешевел."
+    )
+    assert expected in text
+    assert text.count("🧭 К евро:") == 1
+
+
+def cy_plain_eur_summary_inverts_quote_arrow_semantics() -> None:
+    raw = (
+        "💱 <b>Курсы валют | 1 EUR</b>\n"
+        "EUR: USD 1.15 ↑0.01 · GBP 0.85 ↓0.01 · TRY 54.75 ↑0.05 · ILS 3.52 ↓0.02\n"
+        "К ₽: EUR 91.19 ↑0.31 · USD 79.46 ↓0.39\n"
+        "🧭 Рублёвые пары смешанно; для поездок по региону смотрим TRY/ILS.\n\n"
+        "#Кипр #курсы_валют #рынки"
+    )
+    rates = {
+        "EUR": {"value": 91.19, "delta": 0.31},
+        "USD": {"value": 79.46, "delta": -0.39},
+    }
+    text = pulse.replace_ruble_summary(raw, rates)
+    assert (
+        "🧭 К евро: доллар подешевел, фунт подорожал, "
+        "турецкая лира подешевела, шекель подорожал."
+    ) in text
+    eur_summary = pulse.build_plain_eur_summary(raw)
+    assert "0.01" not in eur_summary and "0.05" not in eur_summary and "0.02" not in eur_summary
+
+
+def cy_plain_eur_summary_handles_missing_daily_dynamics() -> None:
+    raw = "💱 Курсы\nEUR: USD 1.15 · GBP 0.86 · TRY 54.75 · ILS 3.52"
+    assert pulse.build_plain_eur_summary(raw) == "🧭 К евро: динамика за день пока недоступна."
+
+
+def cy_two_human_summaries_are_in_reading_order() -> None:
+    raw, rates = _build_fx_text_with_ruble_deltas(1.63, -1.43)
+    text = pulse.replace_ruble_summary(raw, rates)
+    assert text.index("EUR:") < text.index("🧭 К евро:")
+    assert text.index("🧭 К евро:") < text.index("К ₽:")
+    assert text.index("К ₽:") < text.index("🧭 К рублю:")
+
+
+def cy_plain_summary_explains_mixed_ruble_moves_without_repeating_numbers() -> None:
     raw, rates = _build_fx_text_with_ruble_deltas(1.63, -1.43)
     text = pulse.replace_ruble_summary(raw, rates)
     assert "🧭 К рублю: евро подорожал, доллар подешевел." in text
@@ -106,13 +151,14 @@ def cy_safe_runner_uses_same_summary_formatter() -> None:
     assert safe_pulse.replace_ruble_summary is pulse.replace_ruble_summary
     raw, rates = _build_fx_text_with_ruble_deltas(1.63, -1.43)
     text = safe_pulse.replace_ruble_summary(raw, rates)
+    assert "🧭 К евро:" in text
     assert "🧭 К рублю: евро подорожал, доллар подешевел." in text
 
 
-def cy_no_cbr_values_do_not_append_ruble_summary_after_hashtags() -> None:
+def cy_no_cbr_values_keep_eur_summary_but_skip_ruble_summary() -> None:
     raw = (
         "💱 <b>Курсы валют | 1 EUR</b>\n"
-        "EUR: USD 1.14 · GBP 0.86 · TRY 53.14 · ILS 3.41\n\n"
+        "EUR: USD 1.14 · GBP 0.86 · TRY 53.14 ↑0.18 · ILS 3.41 ↑0.02\n\n"
         "#Кипр #курсы_валют #рынки"
     )
     rates = {
@@ -120,7 +166,7 @@ def cy_no_cbr_values_do_not_append_ruble_summary_after_hashtags() -> None:
         "USD": {"value": None, "delta": None},
     }
     text = pulse.replace_ruble_summary(raw, rates)
-    assert text == raw
+    assert "🧭 К евро:" in text
     assert "🧭 К рублю:" not in text
     assert text.rstrip().endswith("#Кипр #курсы_валют #рынки")
 
@@ -150,13 +196,17 @@ def cy_fx_market_hashtag_survives_empty_or_existing_pulse() -> None:
 def main() -> None:
     checks = (
         cy_fx_numeric_lines_stay_unchanged,
-        cy_plain_summary_explains_mixed_moves_without_repeating_numbers,
+        cy_plain_eur_summary_explains_displayed_moves,
+        cy_plain_eur_summary_inverts_quote_arrow_semantics,
+        cy_plain_eur_summary_handles_missing_daily_dynamics,
+        cy_two_human_summaries_are_in_reading_order,
+        cy_plain_summary_explains_mixed_ruble_moves_without_repeating_numbers,
         cy_plain_summary_handles_both_up,
         cy_plain_summary_handles_both_down,
         cy_plain_summary_handles_zero_and_missing,
         cy_missing_deltas_never_restore_old_jargon,
         cy_safe_runner_uses_same_summary_formatter,
-        cy_no_cbr_values_do_not_append_ruble_summary_after_hashtags,
+        cy_no_cbr_values_keep_eur_summary_but_skip_ruble_summary,
         cy_market_pulse_is_compact,
         cy_fx_market_hashtag_survives_empty_or_existing_pulse,
     )


### PR DESCRIPTION
## Goal

Add a second plain-language interpretation line to the Cyprus FX post so readers do not have to decode EUR arrows themselves.

## Result

The numeric lines stay unchanged, followed by two short explanations:

`🧭 К евро: доллар подешевел, фунт почти не изменился, турецкая лира подешевела, шекель почти не изменился.`

`🧭 К рублю: евро подорожал, доллар подешевел.`

## Semantics

The EUR line is quoted as units of another currency per 1 EUR. Therefore:
- `↑` means 1 EUR buys more quote currency -> that quote currency weakened / `подешевела к евро`;
- `↓` means it strengthened / `подорожала к евро`;
- when at least one daily arrow is available, currencies without a visible arrow are described as `почти не изменился/изменилась`;
- when no daily arrows are available at all, the line says `динамика за день пока недоступна`.

The RUB formatter is also made specific to RUB summary lines so the new `🧭 К евро:` line can never be overwritten.

Focused tests cover direction inversion, feminine TRY wording, summary ordering, missing dynamics, safe/test formatter reuse, no-CBR-value behavior, and preservation of numeric lines.

No workflows, Telegram sends, external market requests, secrets or data files are changed.