### PR TITLE
Restore Cyprus visual prompt baseline and add offline PR CI

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,0 +1,86 @@
+name: Cyprus offline PR checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  offline-regressions:
+    name: Offline regressions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install offline test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "requests>=2.32" \
+            "pendulum>=3.0" \
+            "Pillow>=10,<12" \
+            "python-telegram-bot>=20,<21"
+
+      - name: Compile Cyprus modules and offline tests
+        run: |
+          python -m compileall -q \
+            air.py \
+            cyprus_image_recovery.py \
+            cyprus_visual_dedup.py \
+            format_v2.py \
+            image_prompt_cy_scene.py \
+            safe_test_post.py \
+            send_weekly_forecast.py \
+            visibility_context.py \
+            visual_context_cy.py \
+            visual_rules_cy.py \
+            world_en/image_content_guard.py \
+            world_en/imagegen.py \
+            tools/test_air_cy.py \
+            tools/test_cyprus_image_content_guard.py \
+            tools/test_cyprus_image_fallback.py \
+            tools/test_cyprus_visual_dedup.py \
+            tools/test_cyprus_visual_workflow.py \
+            tools/test_format_v2_cy.py \
+            tools/test_format_v2_morning_cy.py \
+            tools/test_imagegen_validation.py \
+            tools/test_visual_cy.py \
+            tools/test_weekly_forecast.py \
+            tools/test_weekly_workflow_schedule.py
+
+      - name: Run offline regressions with external HTTP disabled
+        env:
+          HTTP_PROXY: http://127.0.0.1:9
+          HTTPS_PROXY: http://127.0.0.1:9
+          ALL_PROXY: http://127.0.0.1:9
+          http_proxy: http://127.0.0.1:9
+          https_proxy: http://127.0.0.1:9
+          all_proxy: http://127.0.0.1:9
+          NO_PROXY: localhost,127.0.0.1
+          no_proxy: localhost,127.0.0.1
+          POLLINATIONS_BASE_URL: http://127.0.0.1:9
+          HORDE_BASE_URL: http://127.0.0.1:9
+          CUSTOM_IMAGE_BASE_URL: ""
+        run: |
+          set -euo pipefail
+          python tools/test_visual_cy.py
+          python tools/test_imagegen_validation.py
+          python tools/test_cyprus_image_content_guard.py
+          python tools/test_cyprus_visual_dedup.py
+          python tools/test_cyprus_image_fallback.py
+          python tools/test_cyprus_visual_workflow.py
+          python tools/test_format_v2_cy.py
+          python tools/test_format_v2_morning_cy.py
+          python tools/test_air_cy.py
+          python tools/test_weekly_forecast.py
+          python tools/test_weekly_workflow_schedule.py

--- a/image_prompt_cy_scene.py
+++ b/image_prompt_cy_scene.py
@@ -969,16 +969,18 @@ def _negative_items(
         items.extend(["no rain", "no wet roads or wet rocks"])
     if not ctx.explicit_storm:
         items.extend(["no storm", "no lightning or rough storm sea"])
+    if scene.diagnostics.get("wind_rule"):
+        items.append("no mirror-flat water or still vegetation")
     if ctx.visibility_condition == "clear":
         items.append("no fog")
-    if ctx.visual_forecast_period == "representative_daytime":
-        items.extend(["no sunset", "no night", "no moon-led scene", "no gloomy twilight", "no cold winter palette"])
     if _bay_visuals_disabled():
         items.append(
             "no scenic curved bay, no natural cove, no enclosed tourist lagoon, no elevated postcard coastline"
         )
     elif metadata["selected_scene"] == "small_harbour":
         items.append("no scenic curved tourist bay")
+    if ctx.visual_forecast_period == "representative_daytime":
+        items.extend(["no sunset", "no night", "no moon-led scene", "no gloomy twilight", "no cold winter palette"])
     visibility_window = str(scene.diagnostics.get("visibility_forecast_window") or "none")
     visibility_condition = str(scene.diagnostics.get("visibility_condition") or "clear")
     if visibility_window in {"current_morning", "tomorrow_morning"}:
@@ -1020,8 +1022,6 @@ def _negative_items(
         items.append("natural moon scale, no oversized moon and no fantasy planet")
         if moon_context.get("kind") == "near_full":
             items.append("no perfect full moon")
-    if scene.diagnostics.get("wind_rule"):
-        items.append("no mirror-flat water or still vegetation")
     return _dedupe_semantic_items(items)[:15]
 
 
@@ -1117,8 +1117,8 @@ def _fit_prompt_budget(positive: list[str], negative: list[str]) -> tuple[str, l
         prompt = _compose_prompt(positive, negative)
     if len(prompt) > _PROMPT_TARGET_MAX_CHARS:
         if len(positive) > 6:
-            positive[6] = "Coherent scene-specific composition"
-        positive[-1] = "Natural colors and realistic detail"
+            positive[6] = "Coherent composition"
+        positive[-1] = "Natural colors and detail"
         prompt = _compose_prompt(positive, negative)
     if len(prompt) > _PROMPT_HARD_MAX_CHARS:
         raise ValueError("Cyprus visual prompt exceeds the hard length limit")

--- a/tools/test_visual_cy.py
+++ b/tools/test_visual_cy.py
@@ -1028,10 +1028,20 @@ def cy_disable_bay_visuals_excludes_bays_and_adds_negative_constraints() -> None
             assert not any(token in composition for token in ("aerial", "raised", "wide panorama", "beach curve"))
             low = prompt.lower()
             for clause in (
+                "no map",
+                "satellite imagery",
+                "cartographic view",
+                "aerial map",
+                "screenshot",
+                "browser or app interface",
+                "ui chrome",
+                "screen capture",
                 "no scenic curved bay",
                 "no natural cove",
                 "no enclosed tourist lagoon",
                 "no elevated postcard coastline",
+                "no mirror-flat water",
+                "still vegetation",
             ):
                 assert clause in low
             _assert_compact_prompt_contract(prompt, meta)


### PR DESCRIPTION
## What changed

- Preserve the PR #28 map/UI negative prompt contract while prioritizing factual wind/sea and scene-shape constraints before the 15-item cap.
- Tighten only the final positive-prompt compaction fallback so dense-fog prompts remain within the existing 1,600-character target.
- Extend the production `CY_DISABLE_BAY_VISUALS=1` regression to pin map/UI, bay/cove, and wind/sea constraints together.
- Add a `pull_request`-only Cyprus offline CI workflow with read-only permissions, no secrets, and external HTTP disabled during regression execution.

## Root cause

PR #28 added the required map/satellite/UI exclusion clause. The larger prompt exposed two existing budget-ordering gaps:

1. later wind/sea and small-harbour/no-bay constraints could fall past `[:15]`;
2. the dense-fog case could finish at 1,617 characters even though the target contract is at most 1,600.

The repository had no automatic PR check to catch either regression before merge.

## Impact and scope

This restores the existing visual contract without changing the scene catalog, allocator, weather routing, text generation, fallback behavior, provider configuration, Telegram flows, or image guards.

Prompt-derived style names hash the full final prompt, so corrected prompts do not reuse pre-fix image cache paths. No prompt-version bump is required.

## Validation

- 60 Cyprus synthetic visual checks
- 14 image-generation validation checks
- 8 image content-guard checks
- 13 visual dedup checks
- 7 local image fallback checks
- 24 visual workflow checks
- 38 evening FORMAT_V2 checks
- 50 morning FORMAT_V2 checks
- 5 Cyprus air-quality checks
- 3 weekly forecast checks
- 5 weekly workflow-schedule checks

Total: **227 offline checks passed**.

Local regression execution used fixtures/mocks and redirected external HTTP/provider endpoints to an unavailable localhost port. No manual workflow, Telegram, image provider, or publication call was run.