### PR TITLE
Correct Cyprus air-quality evidence semantics

### DIFF
--- a/air.py
+++ b/air.py
@@ -52,7 +52,7 @@ AIR_KEY = os.getenv("AIRVISUAL_KEY")
 # Единый сетевой таймаут (сек) — можно переопределить переменной окружения HTTP_TIMEOUT
 REQUEST_TIMEOUT = float(os.getenv("HTTP_TIMEOUT", "10"))
 
-CACHE_DIR = Path.home() / ".cache" / "vaybometer"
+CACHE_DIR = Path(os.getenv("VAYBOMETER_CACHE_DIR", str(Path.home() / ".cache" / "vaybometer")))
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 # Kp cache (2 часа TTL, жёсткий максимум — 4 часа)
@@ -83,6 +83,7 @@ CY_AIRQUALITY_URLS = (
     "https://www.airquality.dli.mlsi.gov.cy/",
 )
 CY_AIRQUALITY_TTL_SEC = 10 * 60
+CY_AIR_OBSERVATION_MAX_AGE_MIN = 180
 _CY_AIRQUALITY_CACHE: tuple[float, list[Dict[str, Any]]] | None = None
 
 _CY_STATION_COORDS = {
@@ -123,6 +124,13 @@ _CY_LIMITS = {
     "o3": (100.0, 140.0, 180.0),
     "so2": (100.0, 250.0, 350.0),
     "co": (4000.0, 7000.0, 15000.0),
+}
+
+_CY_POLLUTION_LEVEL_LABELS = {
+    1: "низкий",
+    2: "умеренный",
+    3: "высокий",
+    4: "очень высокий",
 }
 
 # ───────────────────────── Безопасная HTTP-обёртка ─────────────────────────
@@ -214,14 +222,19 @@ def _cy_dominant_pollutant(data: Dict[str, Any]) -> tuple[Optional[str], int]:
     return (_POLLUTANT_LABELS.get(best_key, best_key) if best_key else None), best_level
 
 
-def _cy_official_aqi_from_level(level: int) -> Union[float, str]:
-    return {1: 25.0, 2: 75.0, 3: 125.0, 4: 175.0}.get(level, "н/д")
+def _cy_pollution_level_label(level: Any) -> str:
+    try:
+        return _CY_POLLUTION_LEVEL_LABELS.get(int(level), "н/д")
+    except (TypeError, ValueError):
+        return "н/д"
 
 
 def air_cleanliness_label(air_data: Dict[str, Any]) -> str:
     pollutant = air_data.get("dominant_pollutant")
     level = int(air_data.get("pollution_level") or 0)
-    if level <= 1:
+    if level <= 0:
+        return "⚪ н/д"
+    if level == 1:
         return "🟢 чисто"
     if level == 2:
         return f"🟡 {pollutant}" if pollutant in ("PM₂.₅", "PM₁₀") else "🟡 нормально"
@@ -240,6 +253,31 @@ def _parse_cy_observed_at(value: str) -> tuple[Optional[str], Optional[int]]:
         return dt_obj.to_iso8601_string(), fresh_min
     except Exception:
         return raw, None
+
+
+def _parse_observed_at(value: Any, *, timezone: str = "UTC") -> tuple[Optional[str], Optional[int]]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None, None
+    try:
+        dt_obj = pendulum.parse(raw, tz=timezone)
+        if dt_obj.tzinfo is None:
+            dt_obj = dt_obj.replace(tzinfo=pendulum.timezone(timezone))
+        fresh_min = max(0, int((pendulum.now("UTC") - dt_obj.in_timezone("UTC")).total_minutes()))
+        return dt_obj.to_iso8601_string(), fresh_min
+    except Exception:
+        return raw, None
+
+
+def _air_observation_status(data: Optional[Dict[str, Any]]) -> str:
+    if not data:
+        return "missing"
+    fresh_min = data.get("fresh_min")
+    if not isinstance(fresh_min, (int, float)) or not math.isfinite(float(fresh_min)):
+        return "time_missing"
+    if float(fresh_min) > CY_AIR_OBSERVATION_MAX_AGE_MIN:
+        return "stale"
+    return "fresh"
 
 
 def _normalize_cy_pollutant(raw: str) -> Optional[str]:
@@ -325,12 +363,15 @@ def _parse_cy_airquality_official_html(html_text: str) -> list[Dict[str, Any]]:
         dominant, level = _cy_dominant_pollutant(data)
         data["dominant_pollutant"] = dominant
         data["pollution_level"] = level
-        data["aqi"] = _cy_official_aqi_from_level(level)
-        data["lvl"] = _aqi_level(data["aqi"])
+        data["pollution_category"] = _cy_pollution_level_label(level)
+        # Cyprus publishes a four-level pollution category here, not a numeric AQI.
+        data["aqi"] = None
+        data["lvl"] = data["pollution_category"]
         data["clean_label"] = air_cleanliness_label(data)
         observed_at, fresh_min = _parse_cy_observed_at(observed_raw)
         data["observed_at"] = observed_at
         data["fresh_min"] = fresh_min
+        data["observation_status"] = _air_observation_status(data)
         key = station_name.lower()
         if key not in seen:
             stations.append(data)
@@ -409,12 +450,17 @@ def _src_iqair(lat: float, lon: float) -> Optional[Dict[str, Any]]:
         # В публичном API обычно нет микрограммов PM, оставляем None если нет
         pm25_val = pol.get("p2")   # если ключа нет — будет None (ок)
         pm10_val = pol.get("p1")
-        return {
+        observed_at, fresh_min = _parse_observed_at(pol.get("ts"), timezone="UTC")
+        result = {
             "aqi":  float(aqi_val)  if isinstance(aqi_val,  (int, float)) else None,
             "pm25": float(pm25_val) if isinstance(pm25_val, (int, float)) else None,
             "pm10": float(pm10_val) if isinstance(pm10_val, (int, float)) else None,
             "src": "iqair",
+            "observed_at": observed_at,
+            "fresh_min": fresh_min,
         }
+        result["observation_status"] = _air_observation_status(result)
+        return result
     except Exception as e:
         logging.warning("IQAir parse error: %s", e)
         return None
@@ -430,13 +476,34 @@ def _src_openmeteo(lat: float, lon: float) -> Optional[Dict[str, Any]]:
     try:
         h = resp["hourly"]
         times = h.get("time", []) or []
-        aqi_val  = _pick_nearest_hour(times, h.get("us_aqi", []) or [])
-        pm25_val = _pick_nearest_hour(times, h.get("pm2_5", []) or [])
-        pm10_val = _pick_nearest_hour(times, h.get("pm10", [])  or [])
+        now_iso = time.strftime("%Y-%m-%dT%H:00", time.gmtime())
+        idxs = [i for i, value in enumerate(times) if isinstance(value, str) and value <= now_iso]
+        idx = max(idxs) if idxs else (0 if times else None)
+        if idx is None:
+            return None
+
+        def _value_at(values: Any) -> Optional[float]:
+            if not isinstance(values, list) or idx >= len(values):
+                return None
+            return _float_or_none(values[idx])
+
+        aqi_val = _value_at(h.get("us_aqi", []) or [])
+        pm25_val = _value_at(h.get("pm2_5", []) or [])
+        pm10_val = _value_at(h.get("pm10", []) or [])
         aqi_norm: Union[float, str] = float(aqi_val)  if isinstance(aqi_val,  (int, float)) and math.isfinite(aqi_val)  and aqi_val  >= 0 else "н/д"
         pm25_norm = float(pm25_val) if isinstance(pm25_val, (int, float)) and math.isfinite(pm25_val) and pm25_val >= 0 else None
         pm10_norm = float(pm10_val) if isinstance(pm10_val, (int, float)) and math.isfinite(pm10_val) and pm10_val >= 0 else None
-        return {"aqi": aqi_norm, "pm25": pm25_norm, "pm10": pm10_norm, "src": "openmeteo"}
+        observed_at, fresh_min = _parse_observed_at(times[idx], timezone="UTC")
+        result = {
+            "aqi": aqi_norm,
+            "pm25": pm25_norm,
+            "pm10": pm10_norm,
+            "src": "openmeteo",
+            "observed_at": observed_at,
+            "fresh_min": fresh_min,
+        }
+        result["observation_status"] = _air_observation_status(result)
+        return result
     except Exception as e:
         logging.warning("Open-Meteo AQ parse error: %s", e)
         return None
@@ -448,42 +515,81 @@ def merge_air_sources(*sources: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     Соединяет данные двух источников AQI (приоритет src1 → src2).
     Возвращает {'lvl','aqi','pm25','pm10','src','src_emoji','src_icon'}.
     """
-    aqi_val: Union[float, str, None] = "н/д"
-    src_tag: str = "n/d"
+    available = [dict(s) for s in sources if s]
+    for source in available:
+        source["observation_status"] = _air_observation_status(source)
+    fresh = [source for source in available if source["observation_status"] == "fresh"]
 
-    # AQI источник
-    for s in sources:
-        if not s:
-            continue
-        v = s.get("aqi")
-        if isinstance(v, (int, float)) and math.isfinite(v) and v >= 0:
-            aqi_val = float(v)
-            src_tag = s.get("src") or src_tag
-            break
+    official = next((source for source in fresh if source.get("src") == "cy_official"), None)
+    numeric_aqi_source = next(
+        (
+            source
+            for source in fresh
+            if isinstance(source.get("aqi"), (int, float))
+            and math.isfinite(float(source["aqi"]))
+            and float(source["aqi"]) >= 0
+        ),
+        None,
+    )
+    primary = official or numeric_aqi_source or next(
+        (
+            source
+            for source in fresh
+            if any(isinstance(source.get(key), (int, float)) for key in ("pm25", "pm10", "no2", "o3", "so2", "co"))
+        ),
+        None,
+    )
+
+    if primary is None:
+        status = "stale" if any(source["observation_status"] == "stale" for source in available) else (
+            "time_missing" if any(source["observation_status"] == "time_missing" for source in available) else "missing"
+        )
+        first = available[0] if available else {}
+        src_tag = str(first.get("src") or "n/d")
+        return {
+            "lvl": "н/д",
+            "aqi": "н/д",
+            "pm25": None,
+            "pm10": None,
+            "no2": None,
+            "o3": None,
+            "so2": None,
+            "co": None,
+            "src": "n/d",
+            "src_emoji": SRC_EMOJI["n/d"],
+            "src_icon": SRC_ICON["n/d"],
+            "observation_status": status,
+            "stale_src": src_tag if status == "stale" else None,
+            "stale_observed_at": first.get("observed_at") if status == "stale" else None,
+        }
+
+    src_tag = str(primary.get("src") or "n/d")
+    aqi_val: Union[float, str] = "н/д"
+    if numeric_aqi_source is not None:
+        aqi_val = float(numeric_aqi_source["aqi"])
 
     values: Dict[str, Any] = {}
     for key in ("pm25", "pm10", "no2", "o3", "so2", "co"):
-        for s in sources:
-            if not s:
-                continue
-            value = s.get(key)
-            if isinstance(value, (int, float)) and math.isfinite(value):
-                values[key] = float(value)
-                break
+        value = primary.get(key)
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            values[key] = float(value)
 
     meta: Dict[str, Any] = {}
-    for s in sources:
-        if not s:
-            continue
-        if s.get("src") == src_tag:
-            for key in ("station", "observed_at", "fresh_min", "dominant_pollutant", "pollution_level", "clean_label"):
-                if s.get(key) is not None:
-                    meta[key] = s.get(key)
-            break
+    for key in (
+        "station",
+        "observed_at",
+        "fresh_min",
+        "dominant_pollutant",
+        "pollution_level",
+        "pollution_category",
+        "clean_label",
+    ):
+        if primary.get(key) is not None:
+            meta[key] = primary.get(key)
 
-    lvl = _aqi_level(aqi_val)
+    lvl = _aqi_level(aqi_val) if numeric_aqi_source is not None else str(primary.get("pollution_category") or "н/д")
     src_emoji = SRC_EMOJI.get(src_tag, SRC_EMOJI["n/d"])
-    src_icon  = SRC_ICON.get(src_tag,  SRC_ICON["n/d"])
+    src_icon = SRC_ICON.get(src_tag, SRC_ICON["n/d"])
 
     out = {
         "lvl": lvl,
@@ -497,6 +603,11 @@ def merge_air_sources(*sources: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         "src": src_tag,
         "src_emoji": src_emoji,
         "src_icon": src_icon,
+        "observation_status": "fresh",
+        "aqi_src": numeric_aqi_source.get("src") if numeric_aqi_source else None,
+        "aqi_src_icon": SRC_ICON.get(str(numeric_aqi_source.get("src")), SRC_ICON["n/d"]) if numeric_aqi_source else None,
+        "aqi_observed_at": numeric_aqi_source.get("observed_at") if numeric_aqi_source else None,
+        "aqi_fresh_min": numeric_aqi_source.get("fresh_min") if numeric_aqi_source else None,
     }
     out.update(meta)
     if "clean_label" not in out:

--- a/format_v2.py
+++ b/format_v2.py
@@ -320,7 +320,13 @@ def _air_quality_values(text: str) -> dict[str, float]:
 
 def _has_poor_air_signal(text: str) -> bool:
     values = _air_quality_values(text)
-    if values.get("aqi", 0) >= 100 or values.get("pm25", 0) >= 20 or values.get("pm10", 0) >= 50:
+    official_level = re.search(r"официальн\w*\s+уров\w*\s*(\d)\s*/\s*4", _plain(text), flags=re.I)
+    if (
+        values.get("aqi", 0) >= 100
+        or values.get("pm25", 0) >= 20
+        or values.get("pm10", 0) >= 50
+        or (official_level and int(official_level.group(1)) >= 3)
+    ):
         return True
     low = re.sub(r"\bпыльца\w*", "", _plain(text).lower(), flags=re.I)
     return bool(
@@ -334,6 +340,38 @@ def _has_poor_air_signal(text: str) -> bool:
 
 def _has_visibility_haze(text: str) -> bool:
     return has_structured_visibility_alert(text)
+
+
+def _is_forecast_air_line(line: str) -> bool:
+    low = _plain(line).strip().lower()
+    if not low.startswith(("🏭", "🏙")):
+        return False
+    return bool(
+        re.search(r"\bвоздух\s+завтра(?:\s+утром)?\b", low)
+        or re.search(r"\bпрогноз\w*\s+(?:воздуха|aqi)\b", low)
+        or re.search(r"\baqi\s+завтра(?:\s+утром)?\b", low)
+    )
+
+
+def _forecast_air_lines(lines: list[str]) -> list[str]:
+    return [line for line in lines if _is_forecast_air_line(line)]
+
+
+def _has_structured_dust_evidence(text: str, *, forecast_only: bool = False) -> bool:
+    for raw_line in str(text or "").splitlines():
+        line = _plain(raw_line).strip()
+        low = line.lower()
+        if line.startswith("🌫 Видимость:"):
+            if re.search(r"пылев\w*\s+дымк|сух\w*\s+пыл", low, flags=re.I):
+                return True
+            continue
+        if not line.startswith(("🏭", "🏙")):
+            continue
+        if forecast_only and not _is_forecast_air_line(line):
+            continue
+        if re.search(r"пылев\w*\s+дымк|пыль\s+в\s+воздухе|задымлен|\bсмог\b", low, flags=re.I):
+            return True
+    return False
 
 
 def _format_reason_list(reasons: list[str]) -> str:
@@ -402,13 +440,16 @@ def _evening_flags(lines: list[str]) -> dict[str, bool]:
     max_wind = _max_wind_ms(text)
     max_gust = _max_gust_ms(text)
     max_temp = _max_temperature_c(text)
-    poor_air = _has_poor_air_signal(text)
+    forecast_air_text = "\n".join(_forecast_air_lines(lines))
+    forecast_poor_air = _has_poor_air_signal(forecast_air_text)
+    forecast_dust = _has_structured_dust_evidence(text, forecast_only=True)
     visibility_haze = _has_visibility_haze(text)
     return {
         "storm": _has_actual_storm_signal(text, max_gust),
         "rain": _has_any(text, ("дожд", "ливн", "гроза", "осад")),
-        "dust": poor_air,
-        "visibility_haze": visibility_haze and not poor_air,
+        "dust": forecast_dust,
+        "poor_air": forecast_poor_air,
+        "visibility_haze": visibility_haze and not forecast_dust,
         "heat": _has_any(text, ("жара", "жарко", "перегрев")) or (isinstance(max_temp, (int, float)) and max_temp >= 33),
         "wind": _has_any(text, ("порыв", "сильный ветер", "шторм")) or (isinstance(max_wind, (int, float)) and max_wind >= 7),
         "local": _has_any(text, ("локаль", "местами", "неравномер", "по часам", "микросценар")),
@@ -483,6 +524,8 @@ def _evening_main_scenario(flags: dict[str, bool], score_line: str) -> str:
         return "🧭 Главное завтра: день неоднородный по острову."
     if flags["dust"]:
         return "🧭 Главное завтра: пыль/дымка влияют на воздух и видимость; утром лучше сверить AQI/PM."
+    if flags.get("poor_air"):
+        return "🧭 Главное завтра: прогноз воздуха требует более щадящей активности на улице."
     if flags.get("visibility_haze"):
         return "🧭 Главное завтра: утром местами дымка/туман; на дороге и у побережья лучше проверить видимость."
     if flags["heat"] and flags["wind"]:
@@ -508,6 +551,8 @@ def _evening_nuance(flags: dict[str, bool], has_sea: bool, has_inland: bool) -> 
         return "⚠️ Главный нюанс: осадки возможны локально; по районам погода может отличаться сильнее среднего прогноза."
     if flags["dust"]:
         return "⚠️ Нюанс: при пыли/дыме чувствительным людям лучше сократить активность на улице."
+    if flags.get("poor_air"):
+        return "⚠️ Нюанс: чувствительным людям лучше сократить интенсивную активность на улице."
     if flags.get("visibility_haze"):
         return "⚠️ Нюанс: воздух по текущим данным чистый, но локальная дымка может ухудшать видимость."
     if flags["heat"] and has_inland:
@@ -544,6 +589,8 @@ def _evening_plan(flags: dict[str, bool]) -> str:
         return "✅ План завтра: прогулки у моря — в защищённых местах, ветер перепроверить утром."
     if flags["dust"]:
         return "✅ План завтра: утром оценить видимость/воздух, прогулку сделать короче при дымке."
+    if flags.get("poor_air"):
+        return "✅ План завтра: утром сверить прогноз воздуха и при повышенных значениях выбрать спокойную нагрузку."
     if flags.get("visibility_haze"):
         return "✅ План завтра: утром проверить видимость, особенно для дороги и побережья."
     return "✅ План завтра: обычные дела и прогулки, с короткой проверкой ветра и солнца утром."
@@ -553,6 +600,8 @@ def _clean_air_line(line: str) -> str:
     s = _plain(line).strip()
     if "воздух по городам" in s.lower():
         return _clean_city_air_line(s)
+    if re.search(r"официальн\w*\s+уров|AirQuality CY|📡 IQAir|🛰 OM|свежих наблюдений нет|время наблюдения", s, flags=re.I):
+        return s
     aqi_match = re.search(r"\bAQI\s*(\d+|н/д)", s, flags=re.I)
     pm25_match = re.search(r"(?:PM₂\.₅|PM2\.?5)\s*(\d+)", s, flags=re.I)
     pm10_match = re.search(r"(?:PM₁₀|PM10)\s*(\d+)", s, flags=re.I)
@@ -610,6 +659,8 @@ def _clean_air_line(line: str) -> str:
 
 def _clean_city_air_line(line: str) -> str:
     body = re.sub(r"^🏭\s*Воздух по городам\s*:\s*", "", _plain(line).strip(), flags=re.I)
+    if re.search(r"\b(?:ур\.|уровень)\s*\d\s*/\s*4", body, flags=re.I):
+        return "🏭 Воздух по городам: " + body
     city_re = r"Никосия|Лимассол|Ларнака|Пафос|Айя-Напа|Тродос"
     pollutant_re = r"PM₂\.₅|PM2\.?5|PM₁₀|PM10|NO₂|NO2|O₃|O3|SO₂|SO2|CO"
     value_re = r"\d+(?:[\.,]\d+)?"
@@ -647,8 +698,14 @@ def _air_health_recommendation(line: str) -> str:
                 values[key] = float(match.group(1).replace(",", "."))
             except Exception:
                 pass
-    if values.get("aqi", 0) >= 100 or values.get("pm25", 0) >= 20 or values.get("pm10", 0) >= 50:
-        return "😷 Воздух неидеален: активность на улице короче, окна лучше держать закрытыми в часы пыли/дымки."
+    official_level = re.search(r"официальн\w*\s+уров\w*\s*(\d)\s*/\s*4", s, flags=re.I)
+    if (
+        values.get("aqi", 0) >= 100
+        or values.get("pm25", 0) >= 20
+        or values.get("pm10", 0) >= 50
+        or (official_level and int(official_level.group(1)) >= 3)
+    ):
+        return "poor_air"
     return ""
 
 
@@ -665,7 +722,13 @@ def _air_lines(lines: list[str]) -> list[str]:
             continue
         if "частный датчик" in low or "safecast" in low or "радиа" in low:
             continue
-        if "aqi" not in low and "воздух по городам" not in low:
+        if (
+            "aqi" not in low
+            and "воздух по городам" not in low
+            and "официальный уровень" not in low
+            and "наблюдений нет" not in low
+            and "оценка недоступна" not in low
+        ):
             continue
         cleaned = _clean_air_line(s)
         for part in cleaned.splitlines():
@@ -679,8 +742,23 @@ def _air_is_poor(lines: list[str]) -> bool:
     return any(_air_health_recommendation(line) for line in lines)
 
 
-def _poor_air_advice_line() -> str:
-    return "😷 Воздух неидеален: активность на улице короче, окна лучше держать закрытыми в часы пыли/дымки."
+def _poor_air_advice_line(air_lines: list[str], evidence_text: str, *, forecast: bool = False) -> str:
+    scope = ""
+    for line in air_lines:
+        match = re.search(r"наблюдение\s+в\s+([А-ЯЁа-яё-]+)", _plain(line), flags=re.I)
+        if match:
+            scope = f"В {match.group(1)} "
+            break
+    if not scope and any("воздух по городам" in _plain(line).lower() for line in air_lines):
+        scope = "В отдельных городах "
+    if forecast:
+        scope = "По прогнозу "
+
+    subject = f"{scope}воздух" if scope else "Воздух"
+    advice = f"😷 {subject} неидеален: чувствительным людям лучше сократить интенсивную активность на улице."
+    if _has_structured_dust_evidence(evidence_text, forecast_only=forecast):
+        advice += " В часы подтверждённой пылевой дымки окна лучше держать закрытыми."
+    return advice
 
 
 def _critical_safecast_cy_line(lines: list[str]) -> str:
@@ -1060,7 +1138,7 @@ def build_morning_format_v2(region_name: str, safe_legacy_text: str) -> str:
     else:
         out.append("✅ План: " + plan + ".")
     if poor_air:
-        out.append(_poor_air_advice_line())
+        out.append(_poor_air_advice_line(air, safe_legacy_text))
 
     out.append(tags)
     return "\n".join(out).strip()
@@ -1073,14 +1151,17 @@ def build_evening_format_v2(region_name: str, safe_legacy_text: str) -> str:
     sea = _section_after(lines, "Морские города")
     inland = _section_after(lines, "Континентальные города")
     air = _air_lines(lines)
-    poor_air = _air_is_poor(air)
     radiation = _critical_safecast_cy_line(lines) or _safecast_private_sensor_line()
     astro = _clean_evening_astro(lines)
     score = _first_line_starts(lines, ("✨ VayboMeter завтра:", "✨ VayboMeter:"))
     flags = _evening_flags(lines)
     if storm:
         flags["storm"] = True
-    score = _polish_evening_score(score, flags)
+    poor_air = bool(flags.get("poor_air"))
+    # Preserve the existing score-polish inputs; PR C changes only air messaging scope.
+    score_flags = dict(flags)
+    score_flags["dust"] = _has_poor_air_signal("\n".join(lines))
+    score = _polish_evening_score(score, score_flags)
     nuance = _evening_nuance(flags, bool(sea), bool(inland))
     confidence = _evening_confidence_line(flags)
     visibility = _morning_pick(lines, ("🌫 Видимость:",))
@@ -1131,7 +1212,7 @@ def build_evening_format_v2(region_name: str, safe_legacy_text: str) -> str:
 
     out.append(_evening_plan(flags))
     if poor_air:
-        out.append(_poor_air_advice_line())
+        out.append(_poor_air_advice_line(_forecast_air_lines(lines), safe_legacy_text, forecast=True))
     out.append("#Кипр #погода #здоровье #Никосия #Тродос")
     return "\n".join(out).strip()
 

--- a/post_common.py
+++ b/post_common.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Tuple, Optional, Sequence, Union
 import pendulum
 from telegram import Bot, constants
 
-from utils        import compass, get_fact, kmh_to_ms, smoke_index
+from utils        import compass, get_fact, kmh_to_ms
 from weather      import (
     build_cyprus_visibility_line,
     day_night_stats,
@@ -1506,7 +1506,36 @@ def _air_metric_values(air_now: Dict[str, Any]) -> tuple[Optional[float], Option
     return aqi_f, pm25_f, pm10_f
 
 
+def _air_observation_city(air_now: Dict[str, Any]) -> str:
+    station = str(air_now.get("station") or "").strip().lower()
+    for needle, city in (
+        ("limassol", "Лимассоле"),
+        ("nicosia", "Никосии"),
+        ("larnaca", "Ларнаке"),
+        ("paphos", "Пафосе"),
+        ("paralimni", "Паралимни"),
+        ("ayia marina", "Айя-Марине"),
+        ("zygi", "Зиги"),
+    ):
+        if needle in station:
+            return city
+    return ""
+
+
+def _air_observation_time(air_now: Dict[str, Any]) -> str:
+    observed_at = str(air_now.get("observed_at") or "").strip()
+    if not observed_at:
+        return ""
+    try:
+        return pendulum.parse(observed_at).in_timezone("Asia/Nicosia").format("HH:mm")
+    except Exception:
+        match = re.search(r"\b(\d{1,2}:\d{2})\b", observed_at)
+        return match.group(1) if match else ""
+
+
 def _is_air_bad(air_now: Dict[str, Any]) -> tuple[bool, str]:
+    if air_now.get("observation_status") not in (None, "fresh"):
+        return False, ""
     aqi_f, pm25_f, pm10_f = _air_metric_values(air_now)
     bad = (
         (isinstance(aqi_f, (int, float)) and aqi_f >= 100)
@@ -1515,19 +1544,37 @@ def _is_air_bad(air_now: Dict[str, Any]) -> tuple[bool, str]:
     )
     if not bad:
         return False, "🟢 воздух в норме"
-    return True, "😷 Воздух неидеален: активность на улице короче, окна лучше держать закрытыми в часы пыли/дымки."
+    city = _air_observation_city(air_now)
+    scope = f"В {city} воздух" if city else "По текущему наблюдению воздух"
+    return True, f"😷 {scope} неидеален: чувствительным людям лучше сократить интенсивную активность на улице."
 
 
 def _air_quality_line_from_data(air: Dict[str, Any], *, include_pollen: bool = False) -> Optional[str]:
+    status = str(air.get("observation_status") or "").strip().lower()
+    if status == "stale":
+        return "🏭 Воздух: свежих наблюдений нет; предыдущий официальный замер устарел."
+    if status == "time_missing":
+        return "🏭 Воздух: текущая оценка недоступна — источник не указал время наблюдения."
+    if status == "missing" or not air:
+        return "🏭 Воздух: свежих наблюдений нет."
+
     aqi_f, pm25_f, pm10_f = _air_metric_values(air)
     lbl = _aqi_bucket_label(aqi_f)
 
     parts: list[str] = []
 
-    aqi_part = f"AQI {int(round(aqi_f))}" if isinstance(aqi_f, (int, float)) else "AQI н/д"
-    if lbl:
-        aqi_part += f" ({lbl})"
-    parts.append(aqi_part)
+    official_level = air.get("pollution_level") if air.get("src") == "cy_official" else None
+    if isinstance(official_level, (int, float)) and 1 <= int(official_level) <= 4:
+        category = str(air.get("pollution_category") or "н/д")
+        parts.append(f"официальный уровень {int(official_level)}/4 ({category})")
+
+    if isinstance(aqi_f, (int, float)):
+        aqi_part = f"AQI {int(round(aqi_f))}"
+        aqi_src = str(air.get("aqi_src_icon") or "").strip()
+        details = [value for value in (lbl, aqi_src if air.get("aqi_src") != air.get("src") else "") if value]
+        if details:
+            aqi_part += " (" + "; ".join(details) + ")"
+        parts.append(aqi_part)
 
     pm_part: list[str] = []
     if isinstance(pm25_f, (int, float)):
@@ -1537,10 +1584,6 @@ def _air_quality_line_from_data(air: Dict[str, Any], *, include_pollen: bool = F
     if pm_part:
         parts.append(" / ".join(pm_part))
 
-    em_sm, lbl_sm = smoke_index(pm25_f, pm10_f)
-    if isinstance(lbl_sm, str) and lbl_sm.lower() not in ("низкое", "низкий", "нет", "н/д"):
-        parts.append(f"😮‍💨 задымление: {lbl_sm}")
-
     if include_pollen:
         p = get_pollen() or {}
         risk = p.get("risk")
@@ -1549,6 +1592,16 @@ def _air_quality_line_from_data(air: Dict[str, Any], *, include_pollen: bool = F
 
     if not parts:
         return None
+
+    city = _air_observation_city(air)
+    if city:
+        parts.append(f"наблюдение в {city}")
+    source = str(air.get("src_icon") or "").strip()
+    if source and source != "⚪ н/д":
+        parts.append(source)
+    observed_time = _air_observation_time(air)
+    if observed_time:
+        parts.append(f"данные на {observed_time}")
 
     return "🏭 Воздух: " + " • ".join(parts)
 
@@ -1584,10 +1637,6 @@ def _city_air_metric_hint(data: Dict[str, Any], compact_label: str) -> str:
     if marker not in {"🟡", "🟠", "🔴"}:
         return ""
 
-    pm25 = _fmt_city_air_value(data.get("pm25"))
-    if pm25:
-        return f"PM₂.₅ {pm25}"
-
     pollutant = str(data.get("dominant_pollutant") or "").strip().lower()
     pollutant_map = {
         "pm10": ("PM₁₀", "pm10"),
@@ -1599,12 +1648,18 @@ def _city_air_metric_hint(data: Dict[str, Any], compact_label: str) -> str:
     pollutant = pollutant.replace(".", "")
     for src, dst in {"₀": "0", "₁": "1", "₂": "2", "₃": "3", "₄": "4", "₅": "5", "₆": "6", "₇": "7", "₈": "8", "₉": "9"}.items():
         pollutant = pollutant.replace(src, dst)
+    parts: list[str] = []
+    level = data.get("pollution_level") if data.get("src") == "cy_official" else None
+    if isinstance(level, (int, float)) and 1 <= int(level) <= 4:
+        parts.append(f"ур. {int(level)}/4")
     if pollutant in pollutant_map:
         label, key = pollutant_map[pollutant]
         value = _fmt_city_air_value(data.get(key))
         if value:
-            return f"{label} {value}"
-    return ""
+            parts.append(f"{label} {value}")
+    elif _fmt_city_air_value(data.get("pm25")):
+        parts.append(f"PM₂.₅ {_fmt_city_air_value(data.get('pm25'))}")
+    return "; ".join(parts)
 
 
 def _air_by_city_line(city_pairs: list[tuple[str, tuple[float, float]]]) -> Optional[str]:
@@ -1637,6 +1692,8 @@ def _air_by_city_line(city_pairs: list[tuple[str, tuple[float, float]]]) -> Opti
     for city, _coords in selected:
         data = city_air.get(city)
         if not data:
+            continue
+        if data.get("observation_status") not in (None, "fresh"):
             continue
         label = data.get("clean_label")
         if not isinstance(label, str) or not label.strip():
@@ -2211,10 +2268,13 @@ def build_message(
             P.append("🧲 Космопогода: Kp н/д • 🌬️ " + sw_chunk)
 
         bad_air, _ = _is_air_bad(air_now)
-        air_icon = "🟢" if not bad_air else "🟡"
+        air_status = air_now.get("observation_status")
+        air_icon = "⚪" if air_status not in (None, "fresh") else ("🟢" if not bad_air else "🟡")
+        air_scope = _air_observation_city(air_now)
+        air_summary = f"воздух в {air_scope} {air_icon}" if air_scope else f"воздух по текущему замеру {air_icon}"
         storm = "без шторма" if not storm_region.get("warning") else "штормово"
         kp_status = _kp_status_label(kp_val)
-        P.append(f"🔎 Итого: воздух {air_icon} • {storm} • Kp {kp_status}")
+        P.append(f"🔎 Итого: {air_summary} • {storm} • Kp {kp_status}")
 
         tips = ["вода и завтрак"]
         if not bad_air:
@@ -2273,9 +2333,6 @@ def build_message(
         by_city = _air_by_city_line(sea_pairs + other_pairs)
         if by_city:
             P.append(by_city)
-        bad_air, tip = _is_air_bad(air_now)
-        if bad_air and tip:
-            P.append(tip)
         P.append("———")
 
     visibility_context = get_cyprus_visibility_context(

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -1015,15 +1015,32 @@ def _without_editorial_voice(v2_text: str) -> list[str]:
     ]
 
 
-def _cyprus_voice_conditions(v2_text: str) -> dict[str, object]:
+def _cyprus_voice_conditions(v2_text: str, mode: str = "morning") -> dict[str, object]:
     c = _cyprus_conditions(v2_text)
     plain = _plain(v2_text)
     text = plain.lower()
-    text_without_pollen = re.sub(r"\bпыльца\w*", "", text, flags=re.I)
-    pm25 = _num(r"(?:PM₂\.₅|PM2\.?5)\s*(\d+(?:[\.,]\d+)?)", plain)
-    pm10 = _num(r"(?:PM₁₀|PM10)\s*(\d+(?:[\.,]\d+)?)", plain)
+    evidence_text = text
     aqi = c.get("aqi")
-    explicit_poor_air = "воздух неидеален" in text
+    if not str(mode or "").startswith("morn"):
+        evidence_lines: list[str] = []
+        for raw_line in str(v2_text or "").splitlines():
+            line = _plain(raw_line).strip()
+            low = line.lower()
+            if line.startswith(("🏭", "🏙")) and (
+                re.search(r"\bвоздух\s+завтра(?:\s+утром)?\b", low)
+                or re.search(r"\bпрогноз\w*\s+(?:воздуха|aqi)\b", low)
+                or re.search(r"\baqi\s+завтра(?:\s+утром)?\b", low)
+            ):
+                evidence_lines.append(line)
+            elif line.startswith("🌫 Видимость:") and re.search(r"пылев\w*\s+дымк|сух\w*\s+пыл", low):
+                evidence_lines.append(line)
+        evidence_text = _plain("\n".join(evidence_lines)).lower()
+        aqi = _cyprus_evening_forecast_aqi(v2_text)
+
+    text_without_pollen = re.sub(r"\bпыльца\w*", "", evidence_text, flags=re.I)
+    pm25 = _num(r"(?:PM₂\.₅|PM2\.?5)\s*(\d+(?:[\.,]\d+)?)", evidence_text)
+    pm10 = _num(r"(?:PM₁₀|PM10)\s*(\d+(?:[\.,]\d+)?)", evidence_text)
+    explicit_poor_air = "воздух неидеален" in evidence_text
     explicit_dust = bool(
         re.search(
             r"пыль\s+в\s+воздухе|пылев\w+\s+дымк\w*|задымлен\w*|\bдым\s*/\s*смог\b|(?<![а-яё])дым(?!к|[а-яё])|(?<![а-яё])смог(?![а-яё])",
@@ -1064,7 +1081,7 @@ def _insert_editorial_after(lines: list[str], line_to_add: str, prefixes: tuple[
 def _apply_editorial_voice(v2_text: str, mode: str) -> str:
     lines = _without_editorial_voice(v2_text)
     date_s = _date_from_text(v2_text)
-    conditions = _cyprus_voice_conditions(v2_text)
+    conditions = _cyprus_voice_conditions(v2_text, mode)
     if mode.startswith("morn"):
         line = build_morning_human_line("Кипр", date_s or "today", conditions)
         return _insert_editorial_after(lines, line, ("⚠️ Главный нюанс:", "✨ VayboMeter:"))

--- a/tools/test_air_cy.py
+++ b/tools/test_air_cy.py
@@ -60,6 +60,9 @@ def test_official_parse() -> None:
 
 def test_official_priority_and_city_mapping() -> None:
     rows = air._parse_cy_airquality_official_html(SAMPLE_OFFICIAL_HTML)
+    for row in rows:
+        row["fresh_min"] = 5
+        row["observation_status"] = "fresh"
     old_cache = air._CY_AIRQUALITY_CACHE
     air._CY_AIRQUALITY_CACHE = (time.time(), rows)
     try:
@@ -68,11 +71,13 @@ def test_official_priority_and_city_mapping() -> None:
         assert_true("official_priority", official["station"].startswith("Paralimni"))
         merged = air.merge_air_sources(
             official,
-            {"aqi": 10, "pm10": 10, "src": "iqair"},
-            {"aqi": 20, "pm10": 20, "src": "openmeteo"},
+            {"aqi": 10, "pm10": 10, "src": "iqair", "observed_at": "2026-08-08T08:00:00Z", "fresh_min": 5},
+            {"aqi": 20, "pm10": 20, "src": "openmeteo", "observed_at": "2026-08-08T08:00:00Z", "fresh_min": 5},
         )
         assert_true("official_priority", merged["src"] == "cy_official")
         assert_true("official_priority", merged["src_icon"] == "🇨🇾 AirQuality CY")
+        assert_true("official_priority", merged["aqi"] == 10.0)
+        assert_true("official_priority", merged["aqi_src"] == "iqair")
     finally:
         air._CY_AIRQUALITY_CACHE = old_cache
     print("PASS official_priority_and_city_mapping")
@@ -84,7 +89,14 @@ def test_fallback_when_official_fails() -> None:
     old_openmeteo = air._src_openmeteo
     air._src_cy_airquality_official = lambda lat, lon, city=None: None
     air._src_iqair = lambda lat, lon: None
-    air._src_openmeteo = lambda lat, lon: {"aqi": 33.0, "pm25": 6.0, "pm10": 18.0, "src": "openmeteo"}
+    air._src_openmeteo = lambda lat, lon: {
+        "aqi": 33.0,
+        "pm25": 6.0,
+        "pm10": 18.0,
+        "src": "openmeteo",
+        "observed_at": "2026-08-08T08:00:00Z",
+        "fresh_min": 5,
+    }
     try:
         result = air.get_air(34.707, 33.022)
         assert_true("fallback", result["src"] == "openmeteo")
@@ -94,6 +106,147 @@ def test_fallback_when_official_fails() -> None:
         air._src_iqair = old_iqair
         air._src_openmeteo = old_openmeteo
     print("PASS fallback_when_official_fails")
+
+
+def test_official_levels_are_not_fabricated_aqi() -> None:
+    html = "\n".join(
+        f"<section><h4>{station}</h4><p>PM₁₀: {pm10} μg/m³</p><p>Updated on: 08/08/2026 10:00</p></section>"
+        for station, pm10 in (
+            ("Limassol - Traffic Station", 40),
+            ("Nicosia - Traffic Station", 48),
+            ("Larnaca - Traffic Station", 68),
+            ("Paphos - Traffic Station", 120),
+        )
+    )
+    rows = air._parse_cy_airquality_official_html(html)
+    assert_true("official_levels", [row["pollution_level"] for row in rows] == [1, 2, 3, 4])
+    assert_true("official_levels", [row["pollution_category"] for row in rows] == ["низкий", "умеренный", "высокий", "очень высокий"])
+    assert_true("official_levels", all(row["aqi"] is None for row in rows))
+    assert_true("official_levels", not any(row.get("aqi") in (25, 75, 125, 175) for row in rows))
+    print("PASS official_levels_are_not_fabricated_aqi")
+
+
+def test_stale_and_missing_observations_are_deterministic() -> None:
+    stale_official = {
+        "src": "cy_official",
+        "station": "Limassol - Traffic Station",
+        "pm10": 90.0,
+        "pollution_level": 3,
+        "pollution_category": "высокий",
+        "observed_at": "2026-08-08T04:00:00+03:00",
+        "fresh_min": air.CY_AIR_OBSERVATION_MAX_AGE_MIN + 1,
+    }
+    fresh_fallback = {
+        "src": "openmeteo",
+        "aqi": 42.0,
+        "pm25": 8.0,
+        "pm10": 18.0,
+        "observed_at": "2026-08-08T08:00:00Z",
+        "fresh_min": 5,
+    }
+    fallback = air.merge_air_sources(stale_official, fresh_fallback)
+    assert_true("stale_fallback", fallback["src"] == "openmeteo")
+    assert_true("stale_fallback", fallback["aqi"] == 42.0)
+    assert_true("stale_fallback", fallback["pm10"] == 18.0, "stale official PM must not leak into fresh fallback")
+
+    stale_only = air.merge_air_sources(stale_official)
+    assert_true("stale_only", stale_only["observation_status"] == "stale")
+    assert_true("stale_only", stale_only["aqi"] == "н/д" and stale_only["pm10"] is None)
+
+    missing_time = dict(stale_official, fresh_min=None, observed_at=None)
+    missing_only = air.merge_air_sources(missing_time)
+    assert_true("missing_time", missing_only["observation_status"] == "time_missing")
+    assert_true("missing_time", missing_only["aqi"] == "н/д" and missing_only["pm10"] is None)
+    print("PASS stale_and_missing_observations_are_deterministic")
+
+
+def test_official_line_keeps_category_metrics_source_city_and_time() -> None:
+    sys.modules.setdefault("imghdr", types.SimpleNamespace(what=lambda *_args, **_kwargs: None))
+    import post_common
+
+    official = {
+        "src": "cy_official",
+        "station": "Limassol - Traffic Station",
+        "pm25": 12.0,
+        "pm10": 68.0,
+        "dominant_pollutant": "PM₁₀",
+        "pollution_level": 3,
+        "pollution_category": "высокий",
+        "clean_label": "🟠 PM₁₀",
+        "observed_at": "2026-08-08T08:00:00+03:00",
+        "fresh_min": 5,
+    }
+    numeric = {
+        "src": "openmeteo",
+        "aqi": 42.0,
+        "pm25": 8.0,
+        "pm10": 18.0,
+        "observed_at": "2026-08-08T05:00:00Z",
+        "fresh_min": 5,
+    }
+    line = post_common._air_quality_line_from_data(air.merge_air_sources(official, numeric)) or ""
+    assert_true("official_line", "официальный уровень 3/4 (высокий)" in line)
+    assert_true("official_line", "PM₂.₅ 12 / PM₁₀ 68" in line)
+    assert_true("official_line", "AQI 42" in line and "🛰 OM" in line)
+    assert_true("official_line", "наблюдение в Лимассоле" in line)
+    assert_true("official_line", "🇨🇾 AirQuality CY" in line and "данные на 08:00" in line)
+    assert_true("official_line", "AQI 125" not in line)
+    print("PASS official_line_keeps_category_metrics_source_city_and_time")
+
+
+def test_current_air_does_not_become_tomorrow_guidance() -> None:
+    from format_v2 import build_evening_format_v2, build_morning_format_v2
+
+    evening = """<b>Кипр: погода на завтра (09.08.2026)</b>
+✨ VayboMeter завтра: 7.0/10 — обычный день.
+🏖 <b>Морские города</b>
+Лимассол: 31/24 °C • ясно
+———
+💨 Ветер: 3 м/с • 1012 гПа
+🏭 Воздух сейчас: официальный уровень 3/4 (высокий) • PM₂.₅ 12 / PM₁₀ 68 • наблюдение в Лимассоле • 🇨🇾 AirQuality CY • данные на 08:00
+#Кипр #погода
+"""
+    evening_out = build_evening_format_v2("Кипр", evening)
+    assert_true("current_vs_forecast", "официальный уровень 3/4" in evening_out)
+    assert_true("current_vs_forecast", "пыль/дымка влияют" not in evening_out)
+    assert_true("current_vs_forecast", "прогноз воздуха требует" not in evening_out)
+    assert_true("current_vs_forecast", "😷" not in evening_out and "окна лучше держать" not in evening_out)
+
+    morning = evening.replace("погода на завтра", "погода на сегодня").replace("✨ VayboMeter завтра: 7.0/10 — обычный день.\n", "")
+    morning_out = build_morning_format_v2("Кипр", morning)
+    assert_true("current_city_scope", "В Лимассоле воздух неидеален" in morning_out)
+    assert_true("current_city_scope", "окна лучше держать" not in morning_out)
+    print("PASS current_air_does_not_become_tomorrow_guidance")
+
+
+def test_forecast_air_and_dust_evidence_are_separate() -> None:
+    from format_v2 import build_evening_format_v2
+
+    forecast = """<b>Кипр: погода на завтра (09.08.2026)</b>
+✨ VayboMeter завтра: 7.0/10 — обычный день.
+🏖 <b>Морские города</b>
+Лимассол: 31/24 °C • ясно
+———
+💨 Ветер: 3 м/с • 1012 гПа
+🏭 Прогноз воздуха: AQI 130 • PM₂.₅ 32 • PM₁₀ 68
+#Кипр #погода
+"""
+    without_dust = build_evening_format_v2("Кипр", forecast)
+    assert_true("forecast_air", "прогноз воздуха требует" in without_dust)
+    assert_true("forecast_air", "😷 По прогнозу воздух неидеален" in without_dust)
+    assert_true("forecast_air", "пыль/дымка влияют" not in without_dust)
+    assert_true("forecast_air", "окна лучше держать" not in without_dust)
+
+    with_dust = build_evening_format_v2(
+        "Кипр",
+        forecast.replace(
+            "🏭 Прогноз воздуха:",
+            "🌫 Видимость: завтра утром в Лимассоле (прогноз на 07:00) возможна сухая пылевая дымка; ориентируйтесь на фактическую дальность обзора.\n🏭 Прогноз воздуха:",
+        ),
+    )
+    assert_true("forecast_dust", "пыль/дымка влияют" in with_dust)
+    assert_true("forecast_dust", "В часы подтверждённой пылевой дымки окна лучше держать закрытыми" in with_dust)
+    print("PASS forecast_air_and_dust_evidence_are_separate")
 
 
 def test_city_summary_formatting() -> None:
@@ -120,7 +273,7 @@ def test_city_summary_formatting() -> None:
         assert_true("city_summary", isinstance(line, str))
         assert_true("city_summary", "Воздух по городам:" in line)
         assert_true("city_summary", "Лимассол 🟢" in line)
-        assert_true("city_summary", "Никосия 🟡 (PM₂.₅ 18)" in line)
+        assert_true("city_summary", "Никосия 🟡 (PM₁₀ 42)" in line)
         assert_true("city_summary", "Troodos" not in line)
     finally:
         post_common.get_air_for_cities = old_get
@@ -156,10 +309,15 @@ def test_format_v2_keeps_city_air_line() -> None:
 
 def main() -> None:
     test_official_parse()
+    test_official_levels_are_not_fabricated_aqi()
     test_official_priority_and_city_mapping()
     test_fallback_when_official_fails()
+    test_stale_and_missing_observations_are_deterministic()
+    test_official_line_keeps_category_metrics_source_city_and_time()
     test_city_summary_formatting()
     test_format_v2_keeps_city_air_line()
+    test_current_air_does_not_become_tomorrow_guidance()
+    test_forecast_air_and_dust_evidence_are_separate()
     print("OK: Cyprus air-quality offline checks passed")
 
 

--- a/tools/test_format_v2_cy.py
+++ b/tools/test_format_v2_cy.py
@@ -554,11 +554,13 @@ def cy_evening_safe_pipeline_preserves_new_moon_and_voc() -> None:
     assert "⚫️ VoC 12:00–13:20 — без новых стартов." in text
 
 
-def cy_evening_air_replaces_generic_sensor_focus() -> None:
+def cy_evening_current_air_replaces_sensor_without_tomorrow_advice() -> None:
     text = _safe_test_evening_pipeline(AIR_SENSOR_EVENING)
     assert "🏭 Воздух: AQI 125 (высокий) • PM₂.₅ 20 / PM₁₀ 69" in text
     assert "🏭 Воздух по городам: Никосия 🟠 (PM₁₀) · Лимассол 🟡 · Ларнака 🟡 · Пафос 🟢" in text
-    assert "😷 Воздух неидеален:" in text
+    assert "🧭 Главное завтра: пыль/дымка влияют" not in text
+    assert "😷 Воздух неидеален:" not in text
+    assert "окна лучше держать закрытыми" not in text
     assert "Частный датчик" not in text
     assert "Safecast CY: 0.18" not in text
     assert "🧪" not in text
@@ -578,11 +580,12 @@ def cy_evening_low_aqi_haze_is_visibility_not_poor_air() -> None:
     assert text.splitlines()[-1] == "#Кипр #погода #здоровье #Никосия #Тродос"
 
 
-def cy_evening_dust_haze_keeps_poor_air_warning() -> None:
+def cy_evening_unstructured_dust_text_does_not_create_air_warning() -> None:
     text = build_evening_format_v2("Кипр", DUST_HAZE_EVENING)
-    assert "🧭 Главное завтра: пыль/дымка влияют на воздух и видимость; утром лучше сверить AQI/PM." in text
-    assert "⚠️ Нюанс: при пыли/дыме чувствительным людям лучше сократить активность на улице." in text
-    assert "😷 Воздух неидеален:" in text
+    assert "🧭 Главное завтра: пыль/дымка влияют" not in text
+    assert "⚠️ Нюанс: при пыли/дыме" not in text
+    assert "😷 Воздух неидеален:" not in text
+    assert "окна лучше держать закрытыми" not in text
 
 
 def cy_evening_surf_without_wave_is_not_excellent() -> None:
@@ -860,9 +863,9 @@ def main() -> None:
         cy_morning_sea_summary_uses_coastal_rows_not_sunset,
         cy_evening_safe_pipeline_preserves_moon_illumination_and_plus,
         cy_evening_safe_pipeline_preserves_new_moon_and_voc,
-        cy_evening_air_replaces_generic_sensor_focus,
+        cy_evening_current_air_replaces_sensor_without_tomorrow_advice,
         cy_evening_low_aqi_haze_is_visibility_not_poor_air,
-        cy_evening_dust_haze_keeps_poor_air_warning,
+        cy_evening_unstructured_dust_text_does_not_create_air_warning,
         cy_evening_surf_without_wave_is_not_excellent,
         cy_evening_surf_with_valid_wave_is_cautiously_positive,
         cy_evening_city_air_line_is_compact_and_parenthesized,

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -403,8 +403,8 @@ def cy_morning_preserves_full_moon_line_without_illumination_duplicate() -> None
 
 def cy_morning_poor_air_adds_health_recommendation() -> None:
     text = build_morning_format_v2("Кипр", MORNING_POOR_AIR)
-    assert "😷 Воздух неидеален: активность на улице короче" in text
-    assert "окна лучше держать закрытыми" in text
+    assert "😷 Воздух неидеален: чувствительным людям лучше сократить интенсивную активность на улице" in text
+    assert "окна лучше держать закрытыми" not in text
 
 
 def cy_morning_recent_safecast_elevated_is_omitted() -> None:


### PR DESCRIPTION
## What changed

- Keep Cyprus official pollution levels 1–4 as categorical observations instead of fabricating numeric AQI values 25/75/125/175.
- Preserve official PM₂.₅/PM₁₀ measurements, station/city, source, observation time, and freshness.
- Use numeric AQI only when a fresh fallback source actually provides it, while keeping its provenance separate from official Cyprus measurements.
- Ignore stale or time-unattributed observations deterministically and fall back only to a fresh source.
- Keep current city observations out of tomorrow's island-level air headline, nuance, editorial voice, plan, and health advice.
- Require explicit forecast evidence for tomorrow's air guidance and structured dust-haze evidence before suggesting closed windows.
- Keep local exceedances scoped to the observed city or to explicitly listed cities.

## Root cause

The official Cyprus four-level pollution category was converted into synthetic AQI numbers. FORMAT_V2 then scanned current and city-level air text as if it were forecast evidence, allowing today's local PM/AQI to produce a tomorrow-wide dust headline and window-closing advice. PM values were also labeled as smoke without evidence, and stale/missing observation times were not excluded consistently.

## Impact and scope

Air output now distinguishes official categories, real numeric AQI, current observations, and explicit forecasts. Numeric scoring formulas and the existing visibility/WMO, SUP, pressure, weekly, visual allocator/provider rotation, scene catalog, and astronomy logic are unchanged.

## Validation

- 234 offline checks passed across all 11 PR-CI suites.
- Compileall and `git diff --check` passed.
- External networking was disabled at the Python process level during regression execution.
- Remote tree `96785cf1590d9416cfcc28ca55a53f298b854448` exactly matches the locally tested tree.
- No manual workflow, Telegram, weather/air API, or image-provider call was run.