### PR TITLE
Fix Cyprus SUP gust and offshore safety

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -64,11 +64,7 @@ jobs:
           HTTP_PROXY: http://127.0.0.1:9
           HTTPS_PROXY: http://127.0.0.1:9
           ALL_PROXY: http://127.0.0.1:9
-          http_proxy: http://127.0.0.1:9
-          https_proxy: http://127.0.0.1:9
-          all_proxy: http://127.0.0.1:9
           NO_PROXY: localhost,127.0.0.1
-          no_proxy: localhost,127.0.0.1
           POLLINATIONS_BASE_URL: http://127.0.0.1:9
           HORDE_BASE_URL: http://127.0.0.1:9
           CUSTOM_IMAGE_BASE_URL: ""

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -54,6 +54,7 @@ jobs:
             tools/test_format_v2_cy.py \
             tools/test_format_v2_morning_cy.py \
             tools/test_imagegen_validation.py \
+            tools/test_sup_safety_cy.py \
             tools/test_visual_cy.py \
             tools/test_weekly_forecast.py \
             tools/test_weekly_workflow_schedule.py
@@ -81,6 +82,7 @@ jobs:
           python tools/test_cyprus_visual_workflow.py
           python tools/test_format_v2_cy.py
           python tools/test_format_v2_morning_cy.py
+          python tools/test_sup_safety_cy.py
           python tools/test_air_cy.py
           python tools/test_weekly_forecast.py
           python tools/test_weekly_workflow_schedule.py

--- a/post_common.py
+++ b/post_common.py
@@ -129,6 +129,10 @@ KITE_WAVE_WARN = float(os.getenv("KITE_WAVE_WARN", "2.5"))
 SUP_WIND_GOOD_MAX = float(os.getenv("SUP_WIND_GOOD_MAX", "4"))
 OFFSHORE_SUP_WIND_MIN = float(os.getenv("OFFSHORE_SUP_WIND_MIN", "5"))
 SUP_WAVE_GOOD_MAX = float(os.getenv("SUP_WAVE_GOOD_MAX", "0.6"))
+SUP_GUST_CAUTION_MIN = 12.0
+SUP_GUST_STOP_MIN = 15.0
+SUP_TARGET_HOUR = 12
+SUP_SAMPLE_MAX_OFFSET_MINUTES = 90
 SURF_WAVE_GOOD_MIN = float(os.getenv("SURF_WAVE_GOOD_MIN", "0.9"))
 SURF_WAVE_GOOD_MAX = float(os.getenv("SURF_WAVE_GOOD_MAX", "2.5"))
 SURF_WIND_MAX = float(os.getenv("SURF_WIND_MAX", "10"))
@@ -1761,6 +1765,189 @@ def _shore_class(city: str, wind_from_deg: Optional[float]) -> Tuple[Optional[st
     return "cross", src_label
 
 
+def _target_source_index(
+    raw_times: Sequence[Any],
+    target_date: Any,
+    prefer_hour: int,
+    tz_obj: pendulum.Timezone,
+    max_offset_minutes: int = SUP_SAMPLE_MAX_OFFSET_MINUTES,
+) -> Tuple[Optional[int], Optional[pendulum.DateTime]]:
+    """Pick one original hourly index without compressing malformed timestamps."""
+
+    target = pendulum.datetime(
+        target_date.year,
+        target_date.month,
+        target_date.day,
+        prefer_hour,
+        0,
+        tz=tz_obj,
+    )
+    best_idx: Optional[int] = None
+    best_time: Optional[pendulum.DateTime] = None
+    best_diff: Optional[float] = None
+    for idx, raw_time in enumerate(raw_times or []):
+        try:
+            parsed = pendulum.parse(str(raw_time), tz=tz_obj).in_tz(tz_obj)
+        except Exception:
+            continue
+        if parsed.date() != target_date:
+            continue
+        diff = abs((parsed - target).total_seconds())
+        if best_diff is None or diff < best_diff:
+            best_idx, best_time, best_diff = idx, parsed, diff
+
+    if best_diff is None or best_diff > max_offset_minutes * 60:
+        return None, None
+    return best_idx, best_time
+
+
+def _number_at(values: Any, idx: Optional[int]) -> Optional[float]:
+    if idx is None or not isinstance(values, list) or idx >= len(values):
+        return None
+    try:
+        value = float(values[idx])
+    except (TypeError, ValueError):
+        return None
+    return value if math.isfinite(value) else None
+
+
+def _sup_weather_sample(
+    wm: Dict[str, Any],
+    tz_obj: pendulum.Timezone,
+    target_date: Any,
+    prefer_hour: int = SUP_TARGET_HOUR,
+) -> Dict[str, Any]:
+    """Read wind, gust and direction from exactly one tomorrow hourly row."""
+
+    hourly = wm.get("hourly") or {}
+    raw_times = _pick(hourly, "time", "time_local", "timestamp", default=[])
+    idx, sample_at = _target_source_index(raw_times, target_date, prefer_hour, tz_obj)
+    speed_kmh = _number_at(
+        _pick(hourly, "windspeed_10m", "windspeed", "wind_speed_10m", "wind_speed", default=[]),
+        idx,
+    )
+    gust_kmh = _number_at(
+        _pick(hourly, "windgusts_10m", "wind_gusts_10m", "wind_gusts", default=[]),
+        idx,
+    )
+    wind_dir = _number_at(
+        _pick(
+            hourly,
+            "winddirection_10m",
+            "winddirection",
+            "wind_dir_10m",
+            "wind_dir",
+            default=[],
+        ),
+        idx,
+    )
+    return {
+        "sample_at": sample_at,
+        "wind_ms": kmh_to_ms(speed_kmh),
+        "gust_ms": kmh_to_ms(gust_kmh),
+        "wind_dir": wind_dir,
+    }
+
+
+def _sup_samples_are_aligned(
+    weather_at: Optional[pendulum.DateTime],
+    wave_at: Optional[pendulum.DateTime],
+    target_date: Any,
+    tz_obj: pendulum.Timezone,
+) -> bool:
+    if weather_at is None or wave_at is None:
+        return False
+    try:
+        weather_local = weather_at.in_tz(tz_obj)
+        wave_local = wave_at.in_tz(tz_obj)
+    except Exception:
+        return False
+    if weather_local.date() != target_date or wave_local.date() != target_date:
+        return False
+    return abs((weather_local - wave_local).total_seconds()) <= SUP_SAMPLE_MAX_OFFSET_MINUTES * 60
+
+
+def sup_safety_level(
+    *,
+    wind_ms: Optional[float],
+    gust_ms: Optional[float],
+    wave_h: Optional[float],
+    shore: Optional[str],
+    samples_aligned: bool,
+) -> Optional[str]:
+    """Return excellent/caution/delay; None means no confident SUP advice."""
+
+    wind = float(wind_ms) if isinstance(wind_ms, (int, float)) and math.isfinite(float(wind_ms)) else None
+    gust = float(gust_ms) if isinstance(gust_ms, (int, float)) and math.isfinite(float(gust_ms)) else None
+    wave = float(wave_h) if isinstance(wave_h, (int, float)) and math.isfinite(float(wave_h)) else None
+    shore_kind = shore if shore in {"onshore", "offshore", "cross"} else None
+
+    if gust is not None and gust >= SUP_GUST_STOP_MIN:
+        return "delay"
+    if shore_kind == "offshore" and (
+        (wind is not None and wind >= OFFSHORE_SUP_WIND_MIN)
+        or (gust is not None and gust >= SUP_GUST_CAUTION_MIN)
+    ):
+        return "delay"
+    if gust is not None and gust >= SUP_GUST_CAUTION_MIN:
+        return "caution"
+    if shore_kind == "offshore":
+        return "caution"
+
+    complete = all(value is not None for value in (wind, gust, wave, shore_kind))
+    if not samples_aligned or not complete:
+        return None
+    if shore_kind in {"onshore", "cross"} and wind <= SUP_WIND_GOOD_MAX and wave <= SUP_WAVE_GOOD_MAX:
+        return "excellent"
+    return None
+
+
+def _activity_number(value: float) -> str:
+    return str(int(round(value))) if abs(value - round(value)) < 0.05 else f"{value:.1f}"
+
+
+def _sup_guidance_line(
+    level: Optional[str],
+    *,
+    city: str,
+    wind_ms: Optional[float],
+    gust_ms: Optional[float],
+    wave_h: Optional[float],
+    card: Optional[str],
+    shore: Optional[str],
+    shore_src: Optional[str],
+    sst: Optional[float],
+) -> Optional[str]:
+    if level is None:
+        return None
+
+    facts: List[str] = []
+    if isinstance(wind_ms, (int, float)):
+        facts.append(f"ветер {_activity_number(float(wind_ms))} м/с")
+    if isinstance(gust_ms, (int, float)):
+        facts.append(f"порывы до {_activity_number(float(gust_ms))} м/с")
+    if isinstance(wave_h, (int, float)):
+        facts.append(f"волна {_activity_number(float(wave_h))} м")
+
+    spot_part = (
+        f" @{shore_src}"
+        if shore_src
+        and shore_src not in (city, f"ENV:SHORE_FACE_{_env_city_key(city)}")
+        else ""
+    )
+    env_mark = " (ENV)" if shore_src and shore_src.startswith("ENV:") else ""
+    dir_part = f" ({card}/{shore})" if card and shore else ""
+    evidence = (" • " + " • ".join(facts)) if facts else ""
+
+    if level == "excellent":
+        suit = _wetsuit_hint(sst)
+        suit_part = f" • {suit}" if suit else ""
+        return f"🧜‍♂️ Отлично: SUP{spot_part}{env_mark}{evidence}{dir_part}{suit_part}"
+    if level == "caution":
+        return f"🧜‍♂️ SUP: только опытным и короткая сессия{evidence}{dir_part}."
+    return f"🧜‍♂️ SUP лучше отложить{evidence}{dir_part}."
+
+
 def _fetch_wave_for_tomorrow(
     lat: float,
     lon: float,
@@ -1768,9 +1955,10 @@ def _fetch_wave_for_tomorrow(
     prefer_hour: int = 12,
     timeout_s: int = 18,
     retries: int = 2,
-) -> Tuple[Optional[float], Optional[float]]:
+    target_date: Any = None,
+) -> Tuple[Optional[float], Optional[float], Optional[pendulum.DateTime]]:
     if not requests:
-        return None, None
+        return None, None, None
 
     url = "https://marine-api.open-meteo.com/v1/marine"
     params = {
@@ -1788,31 +1976,31 @@ def _fetch_wave_for_tomorrow(
             j = r.json()
 
             hourly = j.get("hourly") or {}
-            times = [pendulum.parse(t) for t in (hourly.get("time") or []) if t]
-            idx = _nearest_index_for_day(
-                times,
-                pendulum.now(tz_obj).add(days=1).date(),
+            wanted_date = target_date or pendulum.today(tz_obj).add(days=1).date()
+            idx, sample_at = _target_source_index(
+                hourly.get("time") or [],
+                wanted_date,
                 prefer_hour,
                 tz_obj,
             )
             if idx is None:
-                return None, None
+                return None, None, None
 
             h = hourly.get("wave_height") or []
             p = hourly.get("wave_period") or []
             w_h = float(h[idx]) if idx < len(h) and h[idx] is not None else None
             w_t = float(p[idx]) if idx < len(p) and p[idx] is not None else None
-            return w_h, w_t
+            return w_h, w_t, sample_at
 
         except Exception as e:
             last_exc = e
             # не спамим логами: пишем только на последней попытке
             if attempt >= max(1, retries):
                 logging.warning("marine fetch failed: %s", e)
-                return None, None
+                return None, None, None
 
     logging.warning("marine fetch failed: %s", last_exc)
-    return None, None
+    return None, None, None
 
 
 def _wetsuit_hint(sst: Optional[float]) -> Optional[str]:
@@ -1892,7 +2080,14 @@ def _morning_sea_city_lines(
 def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone) -> Optional[str]:
     wm = get_weather(la, lo) or {}
     wind_ms, wind_dir, _, _ = pick_tomorrow_header_metrics(wm, tz_obj)
-    wave_h, _ = _fetch_wave_for_tomorrow(la, lo, tz_obj)
+    target_date = pendulum.today(tz_obj).add(days=1).date()
+    wave_h, _, wave_at = _fetch_wave_for_tomorrow(
+        la,
+        lo,
+        tz_obj,
+        prefer_hour=SUP_TARGET_HOUR,
+        target_date=target_date,
+    )
 
     def _gust_at_noon(wm0: Dict[str, Any], tz0: pendulum.Timezone) -> Optional[float]:
         hourly = wm0.get("hourly") or {}
@@ -1917,6 +2112,28 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
     card = _cardinal(float(wind_dir)) if isinstance(wind_dir, (int, float)) else None
     shore, shore_src = _shore_class(city, float(wind_dir) if isinstance(wind_dir, (int, float)) else None)
 
+    sup_sample = _sup_weather_sample(wm, tz_obj, target_date)
+    sup_wind = sup_sample.get("wind_ms")
+    sup_gust = sup_sample.get("gust_ms")
+    sup_dir = sup_sample.get("wind_dir")
+    sup_card = _cardinal(float(sup_dir)) if isinstance(sup_dir, (int, float)) else None
+    sup_shore, sup_shore_src = _shore_class(
+        city,
+        float(sup_dir) if isinstance(sup_dir, (int, float)) else None,
+    )
+    sup_level = sup_safety_level(
+        wind_ms=sup_wind,
+        gust_ms=sup_gust,
+        wave_h=wave_h,
+        shore=sup_shore,
+        samples_aligned=_sup_samples_are_aligned(
+            sup_sample.get("sample_at"),
+            wave_at,
+            target_date,
+            tz_obj,
+        ),
+    )
+
     kite_good = False
     if wind_val is not None:
         if KITE_WIND_GOOD_MIN <= wind_val <= KITE_WIND_GOOD_MAX:
@@ -1928,13 +2145,6 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
         if wave_h is not None and wave_h >= KITE_WAVE_WARN:
             kite_good = False
 
-    sup_good = False
-    if wind_val is not None:
-        if wave_h is not None and (wind_val <= SUP_WIND_GOOD_MAX) and (wave_h <= SUP_WAVE_GOOD_MAX):
-            sup_good = True
-        if shore == "offshore" and wind_val >= OFFSHORE_SUP_WIND_MIN:
-            sup_good = False
-
     surf_good = False
     if wave_h is not None:
         if SURF_WAVE_GOOD_MIN <= wave_h <= SURF_WAVE_GOOD_MAX and (
@@ -1945,12 +2155,8 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
     goods: List[str] = []
     if kite_good:
         goods.append("Кайт/Винг/Винд")
-    if sup_good:
-        goods.append("SUP")
     if surf_good:
         goods.append("Сёрф")
-    if not goods:
-        return None
 
     dir_part = f" ({card}/{shore})" if card or shore else ""
     spot_part = (
@@ -1962,7 +2168,24 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
     env_mark = " (ENV)" if shore_src and shore_src.startswith("ENV:") else ""
     suit_txt = _wetsuit_hint(sst)
     suit_part = f" • {suit_txt}" if suit_txt else ""
-    return "🧜‍♂️ Отлично: " + "; ".join(goods) + spot_part + env_mark + dir_part + suit_part
+    highlights: List[str] = []
+    if goods:
+        highlights.append("🧜‍♂️ Отлично: " + "; ".join(goods) + spot_part + env_mark + dir_part + suit_part)
+
+    sup_line = _sup_guidance_line(
+        sup_level,
+        city=city,
+        wind_ms=sup_wind,
+        gust_ms=sup_gust,
+        wave_h=wave_h,
+        card=sup_card,
+        shore=sup_shore,
+        shore_src=sup_shore_src,
+        sst=sst,
+    )
+    if sup_line:
+        highlights.append(sup_line)
+    return "\n   ".join(highlights) if highlights else None
 
 
 # ───────────── хэштеги ─────────────

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -25,7 +25,7 @@ except Exception:  # pragma: no cover - local lightweight telegram module fallba
     NetworkError = RetryAfter = ServerError = TimedOut = None  # type: ignore[assignment]
 
 from editorial_voice import build_evening_human_line, build_morning_human_line
-from post_common import build_message
+from post_common import build_message, sup_safety_level
 from post_safety import sanitize_post_text, split_telegram_text, validation_summary
 from visibility_context import (
     has_structured_visibility_alert,
@@ -786,21 +786,59 @@ def _dedupe_score_reasons(reasons: list[str]) -> list[str]:
     return out
 
 
+def _sup_shore_from_line(line: str) -> str | None:
+    low = str(line or "").lower()
+    if "offshore" in low or "от берега" in low:
+        return "offshore"
+    if "onshore" in low or "к берегу" in low:
+        return "onshore"
+    if "cross" in low or "вдоль берега" in low:
+        return "cross"
+    return None
+
+
+def _sup_guard_line(line: str) -> str:
+    wind = _num(r"(?:^|[•;])\s*ветер\s*(\d+(?:[\.,]\d+)?)\s*м/с", line)
+    gust = _num(r"порывы\s*(?:до\s*)?(\d+(?:[\.,]\d+)?)\s*м/с", line)
+    wave = _num(r"волна\s*(\d+(?:[\.,]\d+)?)\s*м", line)
+    shore = _sup_shore_from_line(line)
+    level = sup_safety_level(
+        wind_ms=wind,
+        gust_ms=gust,
+        wave_h=wave,
+        shore=shore,
+        samples_aligned=all(value is not None for value in (wind, gust, wave, shore)),
+    )
+    if level == "excellent":
+        return line
+
+    note_m = re.search(r"\(([^()]+)\)", line)
+    note = f" ({note_m.group(1)})" if note_m else ""
+    if level == "delay":
+        if isinstance(gust, (int, float)) and gust >= 15:
+            reason = f"порывы до {_fmt_ms(gust)} м/с"
+        elif shore == "offshore":
+            reason = "ветер от берега"
+        else:
+            reason = "условия небезопасны"
+        return f"🧜‍♂️ SUP лучше отложить: {reason}{note}."
+    if level == "caution":
+        if isinstance(gust, (int, float)) and gust >= 12:
+            reason = f"порывы до {_fmt_ms(gust)} м/с"
+        elif shore == "offshore":
+            reason = "ветер от берега"
+        else:
+            reason = "условия требуют осторожности"
+        return f"🧜‍♂️ SUP: только опытным и короткая сессия • {reason}{note}."
+    return "🧜‍♂️ SUP: данных для уверенной оценки недостаточно; проверить ветер, порывы, направление и волну перед выходом."
+
+
 def _downgrade_sup_lines(text: str) -> str:
     lines = str(text or "").splitlines()
     out: list[str] = []
-    last_gust: float | None = None
     for line in lines:
-        gust = _num(r"порывы\s*(?:до\s*)?(\d+(?:[\.,]\d+)?)", line)
-        if gust is not None:
-            last_gust = gust
-        if "SUP" in line and "Отлично" in line and isinstance(last_gust, (int, float)) and last_gust >= 12:
-            note_m = re.search(r"\(([^()]+)\)", line)
-            note = f" • {note_m.group(1)}" if note_m else ""
-            if last_gust >= 15:
-                out.append(f"🧜‍♂️ SUP лучше отложить: порывы до {_fmt_ms(last_gust)} м/с{note}.")
-            else:
-                out.append(f"🧜‍♂️ SUP: только опытным и короткая сессия • порывы до {_fmt_ms(last_gust)} м/с{note}.")
+        if "SUP" in line and "Отлично" in line:
+            out.append(_sup_guard_line(line))
             continue
         out.append(line)
     return "\n".join(out)

--- a/tools/test_sup_safety_cy.py
+++ b/tools/test_sup_safety_cy.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline regressions for Cyprus SUP wind/gust/offshore safety."""
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sys
+import types
+from pathlib import Path
+
+os.environ.setdefault("VAYBOMETER_CACHE_DIR", "/tmp/vaybometer-sup-safety-test-cache")
+
+
+try:
+    import pendulum  # type: ignore
+except Exception:  # pragma: no cover - lightweight local offline fallback
+    class _OfflineDuration(dt.timedelta):
+        def total_minutes(self) -> float:
+            return self.total_seconds() / 60.0
+
+    class _OfflineDateTime(dt.datetime):
+        def in_tz(self, _tz):
+            return self
+
+        def in_timezone(self, _tz):
+            return self
+
+        def format(self, pattern: str) -> str:
+            translated = pattern.replace("YYYY", "%Y").replace("MM", "%m").replace("DD", "%d").replace("HH", "%H").replace("mm", "%M")
+            return self.strftime(translated)
+
+        def add(self, *, days: int = 0):
+            value = self + dt.timedelta(days=days)
+            return _OfflineDateTime.fromtimestamp(value.timestamp())
+
+        def __sub__(self, other):
+            value = super().__sub__(other)
+            if isinstance(value, dt.timedelta):
+                return _OfflineDuration(seconds=value.total_seconds())
+            return value
+
+        @property
+        def int_timestamp(self) -> int:
+            return int(self.timestamp())
+
+    class _OfflineTimezone:
+        def __init__(self, name: str):
+            self.name = name
+
+    def _offline_parse(value, tz=None):
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is not None:
+            parsed = parsed.replace(tzinfo=None)
+        return _OfflineDateTime(*parsed.timetuple()[:6], parsed.microsecond)
+
+    pendulum = types.ModuleType("pendulum")
+    pendulum.DateTime = _OfflineDateTime
+    pendulum.Date = dt.date
+    pendulum.Timezone = _OfflineTimezone
+    pendulum.timezone = lambda name: _OfflineTimezone(str(name))
+    pendulum.parse = _offline_parse
+    pendulum.from_format = lambda value, fmt, tz=None: _OfflineDateTime.strptime(
+        str(value),
+        fmt.replace("DD", "%d").replace("MM", "%m").replace("YYYY", "%Y").replace("HH", "%H").replace("mm", "%M"),
+    )
+    pendulum.date = dt.date
+    pendulum.datetime = lambda year, month, day, hour=0, minute=0, second=0, tz=None: _OfflineDateTime(
+        year, month, day, hour, minute, second
+    )
+    pendulum.now = lambda tz=None: _OfflineDateTime.now()
+    pendulum.today = lambda tz=None: _OfflineDateTime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    pendulum.instance = lambda value: value
+    pendulum.tz = types.SimpleNamespace(timezone=types.SimpleNamespace(Timezone=_OfflineTimezone))
+    sys.modules["pendulum"] = pendulum
+
+try:
+    import requests  # noqa: F401
+except Exception:  # pragma: no cover - no network is used by this suite
+    requests_stub = types.ModuleType("requests")
+    requests_stub.get = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("offline"))
+    requests_stub.post = requests_stub.get
+    sys.modules["requests"] = requests_stub
+
+try:
+    import telegram  # noqa: F401
+except Exception:  # pragma: no cover - no Telegram call is used by this suite
+    telegram_stub = types.ModuleType("telegram")
+    telegram_stub.Bot = object
+    telegram_stub.constants = types.SimpleNamespace(ParseMode=types.SimpleNamespace(HTML="HTML"))
+    sys.modules["telegram"] = telegram_stub
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from post_common import (  # noqa: E402
+    _shore_class,
+    _sup_guidance_line,
+    _sup_samples_are_aligned,
+    _sup_weather_sample,
+    sup_safety_level,
+)
+from post_safety import sanitize_post_text  # noqa: E402
+from safe_test_post import _downgrade_sup_lines, _sup_guard_line, _translate_shore_notes  # noqa: E402
+
+
+TZ = pendulum.timezone("Asia/Nicosia")
+TARGET_DATE = pendulum.date(2026, 8, 10)
+
+
+def _weather(
+    *,
+    sample_time: str = "2026-08-10T12:00",
+    wind_ms: float | None = 3.0,
+    gust_ms: float | None = 7.0,
+    wind_dir: float | None = 180.0,
+) -> dict:
+    return {
+        "hourly": {
+            "time": [sample_time],
+            "windspeed_10m": [None if wind_ms is None else wind_ms * 3.6],
+            "windgusts_10m": [None if gust_ms is None else gust_ms * 3.6],
+            "winddirection_10m": [wind_dir],
+        }
+    }
+
+
+def _decision(
+    *,
+    wind_ms: float | None = 3.0,
+    gust_ms: float | None = 7.0,
+    wave_h: float | None = 0.3,
+    wind_dir: float | None = 180.0,
+    weather_time: str = "2026-08-10T12:00",
+    wave_time: str = "2026-08-10T12:00",
+) -> str | None:
+    sample = _sup_weather_sample(
+        _weather(
+            sample_time=weather_time,
+            wind_ms=wind_ms,
+            gust_ms=gust_ms,
+            wind_dir=wind_dir,
+        ),
+        TZ,
+        TARGET_DATE,
+    )
+    shore, _ = _shore_class("Limassol", sample.get("wind_dir"))
+    wave_at = pendulum.parse(wave_time, tz=TZ)
+    return sup_safety_level(
+        wind_ms=sample.get("wind_ms"),
+        gust_ms=sample.get("gust_ms"),
+        wave_h=wave_h,
+        shore=shore,
+        samples_aligned=_sup_samples_are_aligned(
+            sample.get("sample_at"),
+            wave_at,
+            TARGET_DATE,
+            TZ,
+        ),
+    )
+
+
+def calm_onshore_is_excellent() -> None:
+    assert _decision(wind_dir=180.0) == "excellent"
+
+
+def calm_cross_shore_is_excellent() -> None:
+    assert _decision(wind_dir=90.0) == "excellent"
+
+
+def gusts_12_to_14_are_caution_even_with_light_wind() -> None:
+    assert _decision(wind_ms=2.5, gust_ms=12.0) == "caution"
+    assert _decision(wind_ms=2.5, gust_ms=14.9) == "caution"
+
+
+def gusts_15_or_more_delay_sup() -> None:
+    assert _decision(wind_ms=2.5, gust_ms=15.0) == "delay"
+    assert _decision(wind_ms=2.5, gust_ms=18.0) == "delay"
+
+
+def offshore_light_wind_is_never_excellent() -> None:
+    assert _decision(wind_ms=2.5, gust_ms=6.0, wind_dir=0.0) == "caution"
+
+
+def offshore_from_5_ms_is_stricter() -> None:
+    assert _decision(wind_ms=5.0, gust_ms=7.0, wind_dir=0.0) == "delay"
+
+
+def offshore_with_strong_gusts_is_stricter() -> None:
+    assert _decision(wind_ms=2.5, gust_ms=13.0, wind_dir=0.0) == "delay"
+    assert _decision(wind_ms=2.5, gust_ms=15.0, wind_dir=0.0) == "delay"
+
+
+def missing_sup_evidence_is_fail_closed() -> None:
+    assert _decision(gust_ms=None) is None
+    assert _decision(wind_dir=None) is None
+    assert _decision(wave_h=None) is None
+
+
+def wrong_day_or_mixed_window_is_fail_closed() -> None:
+    assert _decision(weather_time="2026-08-09T12:00") is None
+    assert _decision(wave_time="2026-08-10T15:00") is None
+
+
+def malformed_time_does_not_shift_metric_arrays() -> None:
+    weather = {
+        "hourly": {
+            "time": ["not-a-time", "2026-08-10T12:00"],
+            "windspeed_10m": [36.0, 10.8],
+            "windgusts_10m": [64.8, 25.2],
+            "winddirection_10m": [0.0, 180.0],
+        }
+    }
+    sample = _sup_weather_sample(weather, TZ, TARGET_DATE)
+    assert round(sample["wind_ms"], 1) == 3.0
+    assert round(sample["gust_ms"], 1) == 7.0
+    assert sample["wind_dir"] == 180.0
+
+
+def russian_direction_wording_is_preserved() -> None:
+    raw = _sup_guidance_line(
+        "excellent",
+        city="Limassol",
+        wind_ms=3.0,
+        gust_ms=7.0,
+        wave_h=0.3,
+        card="S",
+        shore="onshore",
+        shore_src="Limassol",
+        sst=27.0,
+    )
+    assert raw is not None
+    safe = sanitize_post_text(_translate_shore_notes(raw)).text
+    assert "Отлично: SUP" in safe
+    assert "(южный ветер, к берегу)" in safe
+    assert "/onshore" not in safe
+
+
+def format_v2_guard_uses_sup_period_not_previous_city_gust() -> None:
+    text = "\n".join(
+        (
+            "Лимассол: 30/24 °C • 💨 3 м/с • порывы до 16 м/с",
+            "🧜‍♂️ Отлично: SUP • ветер 3 м/с • порывы до 7 м/с • волна 0.3 м (южный ветер, к берегу)",
+        )
+    )
+    guarded = _downgrade_sup_lines(text)
+    assert "Отлично: SUP" in guarded
+    assert "только опытным" not in guarded
+    assert "лучше отложить" not in guarded
+
+
+def format_v2_guard_cannot_upgrade_or_hide_unsafe_sup() -> None:
+    caution = _sup_guard_line(
+        "🧜‍♂️ Отлично: SUP • ветер 3 м/с • порывы до 13 м/с • волна 0.3 м (южный ветер, к берегу)"
+    )
+    assert "Отлично: SUP" not in caution
+    assert "только опытным и короткая сессия" in caution
+    assert "порывы до 13 м/с" in caution
+
+    delay = _sup_guard_line(
+        "🧜‍♂️ Отлично: SUP • ветер 3 м/с • порывы до 15 м/с • волна 0.3 м (южный ветер, к берегу)"
+    )
+    assert "Отлично: SUP" not in delay
+    assert "SUP лучше отложить" in delay
+    assert "порывы до 15 м/с" in delay
+
+    offshore = _sup_guard_line(
+        "🧜‍♂️ Отлично: SUP • ветер 5 м/с • порывы до 7 м/с • волна 0.3 м (северный ветер, от берега)"
+    )
+    assert "Отлично: SUP" not in offshore
+    assert "SUP лучше отложить" in offshore
+    assert "ветер от берега" in offshore
+
+
+def format_v2_guard_rejects_partial_evidence_without_touching_other_sports() -> None:
+    text = "\n".join(
+        (
+            "🧜‍♂️ Отлично: Кайт/Винг/Винд; Сёрф (западный ветер, вдоль берега)",
+            "🧜‍♂️ Отлично: SUP (южный ветер, к берегу)",
+        )
+    )
+    guarded = _downgrade_sup_lines(text)
+    assert "Отлично: Кайт/Винг/Винд; Сёрф" in guarded
+    assert "Отлично: SUP" not in guarded
+    assert "данных для уверенной оценки недостаточно" in guarded
+
+
+CHECKS = [
+    calm_onshore_is_excellent,
+    calm_cross_shore_is_excellent,
+    gusts_12_to_14_are_caution_even_with_light_wind,
+    gusts_15_or_more_delay_sup,
+    offshore_light_wind_is_never_excellent,
+    offshore_from_5_ms_is_stricter,
+    offshore_with_strong_gusts_is_stricter,
+    missing_sup_evidence_is_fail_closed,
+    wrong_day_or_mixed_window_is_fail_closed,
+    malformed_time_does_not_shift_metric_arrays,
+    russian_direction_wording_is_preserved,
+    format_v2_guard_uses_sup_period_not_previous_city_gust,
+    format_v2_guard_cannot_upgrade_or_hide_unsafe_sup,
+    format_v2_guard_rejects_partial_evidence_without_touching_other_sports,
+]
+
+
+def main() -> int:
+    for check in CHECKS:
+        check()
+    print(f"OK: {len(CHECKS)} Cyprus SUP safety checks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- makes `Отлично: SUP` require complete wind, gust, direction and wave evidence from one aligned tomorrow midday period;
- treats gusts from 12 to under 15 m/s as experienced-only/short-session conditions and gusts from 15 m/s as a reason to postpone;
- blocks an excellent SUP recommendation for confirmed offshore wind, with stricter handling when offshore combines with wind from 5 m/s or elevated gusts;
- removes current-observation and mismatched-hour fallbacks from the SUP decision while preserving the existing kite/wing and surf paths;
- makes FORMAT_V2 re-check an excellent SUP line from its own aligned evidence, so a later polish cannot hide gust/offshore risk or promote partial data;
- adds a dedicated offline regression suite and registers it in the existing PR checks.

## Root cause

The legacy water-activity path mixed wind/direction, gust and marine values selected by different helpers and could fall back to current observations. Offshore only cancelled SUP from 5 m/s, and FORMAT_V2 used the last gust seen in surrounding text rather than evidence tied to the SUP period.

## Validation

- 248 checks across all 12 offline PR suites passed with `socket.connect` disabled;
- 14 new SUP-specific checks cover safe onshore/cross-shore, 12/15 m/s gust thresholds, offshore combinations, missing evidence, wrong dates, mismatched windows, malformed timestamps, Russian direction wording and FORMAT_V2 fail-closed behavior;
- `compileall` and `git diff --check` passed;
- local tested tree and remote tree are identical: `6eceedaa62f93d841f8e1e3e36412224863829ed`.

No project API, Telegram delivery, image generation, manual workflow dispatch or publication was run.