### PR TITLE
Fix Cyprus morning forecast date alignment

### DIFF
--- a/post_common.py
+++ b/post_common.py
@@ -266,7 +266,16 @@ def _daily_idx_for_date(
     try:
         daily = wm.get("daily") or {}
         times = daily.get("time") or daily.get("date") or []
+        try:
+            target_key = date_obj.to_date_string()
+        except Exception:
+            target_key = str(date_obj)[:10]
         for i, t in enumerate(times):
+            raw = str(t or "").strip()
+            if re.fullmatch(r"\d{4}-\d{2}-\d{2}", raw):
+                if raw == target_key:
+                    return i
+                continue
             dt_i = _parse_iso_to_tz(t, tz)
             if dt_i and dt_i.date() == date_obj:
                 return i
@@ -1811,6 +1820,136 @@ def _number_at(values: Any, idx: Optional[int]) -> Optional[float]:
     return value if math.isfinite(value) else None
 
 
+def _value_at(values: Any, idx: Optional[int]) -> Any:
+    if idx is None or not isinstance(values, list) or idx >= len(values):
+        return None
+    return values[idx]
+
+
+def _source_indices_for_date(
+    raw_times: Sequence[Any],
+    target_date: Any,
+    tz_obj: pendulum.Timezone,
+) -> List[int]:
+    """Return original source indices for one local date without compressing bad timestamps."""
+
+    indices: List[int] = []
+    for idx, raw_time in enumerate(raw_times or []):
+        try:
+            parsed = pendulum.parse(str(raw_time), tz=tz_obj).in_tz(tz_obj)
+        except Exception:
+            continue
+        if parsed.date() == target_date:
+            indices.append(idx)
+    return indices
+
+
+def _city_daily_metrics_for_date(
+    wm: Dict[str, Any],
+    tz_obj: pendulum.Timezone,
+    target_date: Any,
+) -> Tuple[Optional[float], Optional[float], Any]:
+    daily = wm.get("daily") or {}
+    idx = _daily_idx_for_date(wm, tz_obj, target_date)
+    if idx is None:
+        return None, None, None
+    tmax = _number_at(
+        _pick(daily, "temperature_2m_max", "temperature_max", "temp_max", default=[]),
+        idx,
+    )
+    tmin = _number_at(
+        _pick(daily, "temperature_2m_min", "temperature_min", "temp_min", default=[]),
+        idx,
+    )
+    weather_code = _value_at(_pick(daily, "weathercode", "weather_code", default=[]), idx)
+    return tmax, tmin, weather_code
+
+
+def _city_header_metrics_for_date(
+    wm: Dict[str, Any],
+    tz_obj: pendulum.Timezone,
+    target_date: Any,
+) -> Tuple[Optional[float], Optional[int], Optional[int], str, Optional[float]]:
+    """Read city wind, pressure and gusts only from the requested local forecast date."""
+
+    hourly = wm.get("hourly") or {}
+    raw_times = _pick(hourly, "time", "time_local", "timestamp", default=[])
+    indices = _source_indices_for_date(raw_times, target_date, tz_obj)
+    if not indices:
+        return None, None, None, "→", None
+
+    idx_noon, _ = _target_source_index(
+        raw_times,
+        target_date,
+        12,
+        tz_obj,
+        max_offset_minutes=24 * 60,
+    )
+    idx_morn, _ = _target_source_index(
+        raw_times,
+        target_date,
+        6,
+        tz_obj,
+        max_offset_minutes=24 * 60,
+    )
+    speed_values = _pick(
+        hourly,
+        "windspeed_10m",
+        "windspeed",
+        "wind_speed_10m",
+        "wind_speed",
+        default=[],
+    )
+    direction_values = _pick(
+        hourly,
+        "winddirection_10m",
+        "winddirection",
+        "wind_dir_10m",
+        "wind_dir",
+        default=[],
+    )
+    pressure_values = _pick(hourly, "surface_pressure", "pressure", default=[])
+    gust_values = _pick(
+        hourly,
+        "windgusts_10m",
+        "wind_gusts_10m",
+        "wind_gusts",
+        default=[],
+    )
+
+    speed_kmh = _number_at(speed_values, idx_noon)
+    direction = _number_at(direction_values, idx_noon)
+    pressure_noon = _number_at(pressure_values, idx_noon)
+    pressure_morn = _number_at(pressure_values, idx_morn)
+
+    if speed_kmh is None:
+        same_day_speeds = [value for i in indices if (value := _number_at(speed_values, i)) is not None]
+        if same_day_speeds:
+            speed_kmh = sum(same_day_speeds) / len(same_day_speeds)
+    if direction is None:
+        same_day_dirs = [value for i in indices if (value := _number_at(direction_values, i)) is not None]
+        direction = _circular_mean_deg(same_day_dirs)
+    if pressure_noon is None:
+        same_day_pressures = [value for i in indices if (value := _number_at(pressure_values, i)) is not None]
+        if same_day_pressures:
+            pressure_noon = sum(same_day_pressures) / len(same_day_pressures)
+
+    gusts_kmh = [value for i in indices if (value := _number_at(gust_values, i)) is not None]
+    max_gust_kmh = max(gusts_kmh) if gusts_kmh else None
+    trend = "→"
+    if pressure_noon is not None and pressure_morn is not None:
+        diff = pressure_noon - pressure_morn
+        trend = "↑" if diff >= 0.3 else "↓" if diff <= -0.3 else "→"
+
+    return (
+        kmh_to_ms(speed_kmh) if speed_kmh is not None else None,
+        int(round(direction)) if direction is not None else None,
+        int(round(pressure_noon)) if pressure_noon is not None else None,
+        trend,
+        kmh_to_ms(max_gust_kmh) if max_gust_kmh is not None else None,
+    )
+
+
 def _sup_weather_sample(
     wm: Dict[str, Any],
     tz_obj: pendulum.Timezone,
@@ -2023,30 +2162,33 @@ def _wetsuit_hint(sst: Optional[float]) -> Optional[str]:
 
 
 def _city_detail_line(
-    city: str, la: float, lo: float, tz_obj: pendulum.Timezone, include_sst: bool
+    city: str,
+    la: float,
+    lo: float,
+    tz_obj: pendulum.Timezone,
+    include_sst: bool,
+    target_date: Any = None,
 ) -> tuple[Optional[float], Optional[str]]:
-    tz_name = tz_obj.name
-    tmax, tmin = fetch_tomorrow_temps(la, lo, tz=tz_name)
-    if tmax is None:
-        st_fb = day_night_stats(la, lo, tz=tz_name) or {}
-        tmax = st_fb.get("t_day_max")
-        tmin = st_fb.get("t_night_min")
+    wanted_date = target_date or pendulum.today(tz_obj).add(days=1).date()
+    wm = get_weather(la, lo) or {}
+    tmax, tmin, weather_code = _city_daily_metrics_for_date(wm, tz_obj, wanted_date)
     if tmax is None:
         return None, None
-    tmin = tmin if tmin is not None else tmax
 
-    wm = get_weather(la, lo) or {}
-    wcx = (wm.get("daily", {}) or {}).get("weathercode", [])
-    wcx = wcx[1] if isinstance(wcx, list) and len(wcx) > 1 else None
-    descx = code_desc(wcx) or "—"
-
-    wind_ms, wind_dir, press_val, press_trend = pick_tomorrow_header_metrics(wm, tz_obj)
-    storm = storm_flags_for_tomorrow(wm, tz_obj)
-    gust = storm.get("max_gust_ms")
+    descx = code_desc(weather_code)
+    wind_ms, wind_dir, press_val, press_trend, gust = _city_header_metrics_for_date(
+        wm,
+        tz_obj,
+        wanted_date,
+    )
 
     name_html = f"<b>{_escape_html(_ru_city(city))}</b>"
-    temp_part = f"{round(float(tmax)):.0f}/{round(float(tmin)):.0f} °C"
-    parts = [f"{name_html}: {temp_part}", f"{descx}"]
+    temp_part = f"{round(float(tmax)):.0f} °C"
+    if isinstance(tmin, (int, float)):
+        temp_part = f"{round(float(tmax)):.0f}/{round(float(tmin)):.0f} °C"
+    parts = [f"{name_html}: {temp_part}"]
+    if descx:
+        parts.append(descx)
     if isinstance(wind_ms, (int, float)):
         wind_part = f"💨 {float(wind_ms):.1f} м/с"
         if isinstance(wind_dir, int):
@@ -2066,12 +2208,21 @@ def _city_detail_line(
 def _morning_sea_city_lines(
     sea_pairs: Sequence[tuple[str, tuple[float, float]]],
     tz_obj: pendulum.Timezone,
+    target_date: Any = None,
 ) -> List[str]:
     """Build morning coastal rows through the canonical city formatter with SST."""
 
+    wanted_date = target_date or pendulum.today(tz_obj).date()
     rows: List[str] = []
     for city, (la, lo) in sea_pairs:
-        _tmax, line = _city_detail_line(city, la, lo, tz_obj, include_sst=True)
+        _tmax, line = _city_detail_line(
+            city,
+            la,
+            lo,
+            tz_obj,
+            include_sst=True,
+            target_date=wanted_date,
+        )
         if line:
             rows.append(line)
     return rows
@@ -2386,7 +2537,14 @@ def build_message(
             all_pairs = list(spairs) + list(opairs)
             out: List[Tuple[str, float]] = []
             for city, (la, lo) in all_pairs:
-                tmax, _line = _city_detail_line(city, la, lo, tz_obj, include_sst=False)
+                tmax, _line = _city_detail_line(
+                    city,
+                    la,
+                    lo,
+                    tz_obj,
+                    include_sst=False,
+                    target_date=today.date(),
+                )
                 if isinstance(tmax, (int, float)):
                     out.append((_ru_city(city), float(tmax)))
             return out
@@ -2433,7 +2591,7 @@ def build_message(
         if uv_line:
             P.append(uv_line)
 
-        sea_rows_morning = _morning_sea_city_lines(sea_pairs, tz_obj)
+        sea_rows_morning = _morning_sea_city_lines(sea_pairs, tz_obj, target_date=today.date())
         if sea_rows_morning:
             P.extend(sea_rows_morning)
 

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import json
 import os
 import re
@@ -61,6 +62,7 @@ from safe_test_post import (  # noqa: E402
     finalize_hashtags_at_end,
     _cyprus_main_nuance,
     _cyprus_evening_score_line,
+    _cyprus_feels_line,
     _cyprus_score_line,
     _cyprus_smart_plan_line,
     _inject_morning_score,
@@ -308,11 +310,12 @@ def cy_morning_adds_concise_sea_block_when_available() -> None:
 
 
 def cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening() -> None:
-    calls: list[tuple[str, float, float, bool]] = []
+    target_date = date(2026, 6, 27)
+    calls: list[tuple[str, float, float, bool, date | None]] = []
     old_city_detail_line = post_common_module._city_detail_line
 
-    def fake_city_detail_line(city, la, lo, _tz_obj, include_sst):
-        calls.append((city, la, lo, include_sst))
+    def fake_city_detail_line(city, la, lo, _tz_obj, include_sst, target_date=None):
+        calls.append((city, la, lo, include_sst, target_date))
         temperatures = {"Лимассол": 26.0, "Ларнака": 28.0}
         sst = temperatures[city]
         return 34.0, f"<b>{city}</b>: 34/25 °C • ясно • 🌊 {sst:.0f}"
@@ -326,11 +329,12 @@ def cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening() -> None
         rows = post_common_module._morning_sea_city_lines(
             pairs,
             types.SimpleNamespace(name="Asia/Nicosia"),
+            target_date=target_date,
         )
         assert [line.split(":", 1)[0] for line in rows] == ["<b>Лимассол</b>", "<b>Ларнака</b>"]
         assert calls == [
-            ("Лимассол", 34.68, 33.04, True),
-            ("Ларнака", 34.92, 33.63, True),
+            ("Лимассол", 34.68, 33.04, True, target_date),
+            ("Ларнака", 34.92, 33.63, True, target_date),
         ]
 
         raw_morning = MORNING_NO_SEA.replace(
@@ -354,11 +358,357 @@ def cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening() -> None
         assert post_common_module._morning_sea_city_lines(
             pairs,
             types.SimpleNamespace(name="Asia/Nicosia"),
+            target_date=target_date,
         ) == []
         fallback = build_morning_format_v2("Кипр", MORNING_NO_SEA)
         assert "данные о температуре воды обновляются" in fallback
     finally:
         post_common_module._city_detail_line = old_city_detail_line
+
+
+class _ForecastFixtureDateTime(dt.datetime):
+    def in_tz(self, _tz):
+        return self
+
+    def format(self, pattern: str) -> str:
+        translated = pattern.replace("DD", "%d").replace("MM", "%m").replace("YYYY", "%Y")
+        translated = translated.replace("HH", "%H").replace("mm", "%M")
+        return self.strftime(translated)
+
+    def add(self, *, days: int = 0, hours: int = 0, minutes: int = 0):
+        value = self + dt.timedelta(days=days, hours=hours, minutes=minutes)
+        return _ForecastFixtureDateTime(
+            value.year,
+            value.month,
+            value.day,
+            value.hour,
+            value.minute,
+            value.second,
+            value.microsecond,
+        )
+
+
+def _replace_attrs(target, replacements: dict[str, object], callback):
+    missing = object()
+    previous = {name: getattr(target, name, missing) for name in replacements}
+    try:
+        for name, value in replacements.items():
+            setattr(target, name, value)
+        return callback()
+    finally:
+        for name, value in previous.items():
+            if value is missing:
+                delattr(target, name)
+            else:
+                setattr(target, name, value)
+
+
+def _with_forecast_clock(callback):
+    fixed_today = _ForecastFixtureDateTime(2026, 8, 9)
+
+    def parse(value, tz=None):
+        del tz
+        parsed = dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is not None:
+            parsed = parsed.replace(tzinfo=None)
+        return _ForecastFixtureDateTime(
+            parsed.year,
+            parsed.month,
+            parsed.day,
+            parsed.hour,
+            parsed.minute,
+            parsed.second,
+            parsed.microsecond,
+        )
+
+    def make_datetime(year, month, day, hour=0, minute=0, second=0, tz=None):
+        del tz
+        return _ForecastFixtureDateTime(year, month, day, hour, minute, second)
+
+    return _replace_attrs(
+        post_common_module.pendulum,
+        {
+            "parse": parse,
+            "datetime": make_datetime,
+            "today": lambda _tz=None: fixed_today,
+        },
+        callback,
+    )
+
+
+def _forecast_payload(
+    *,
+    today_high: float,
+    today_low: float,
+    tomorrow_high: float,
+    tomorrow_low: float,
+) -> dict:
+    return {
+        "daily": {
+            "time": ["2026-08-10", "not-a-date", "2026-08-09"],
+            "temperature_2m_max": [tomorrow_high, 99.0, today_high],
+            "temperature_2m_min": [tomorrow_low, 88.0, today_low],
+            "weathercode": [95, 71, 0],
+            "uv_index_max": [4.0, 99.0, 9.0],
+        },
+        "hourly": {
+            "time": [
+                "2026-08-10T06:00",
+                "not-an-hour",
+                "2026-08-09T06:00",
+                "2026-08-09T12:00",
+                "2026-08-10T12:00",
+            ],
+            "windspeed_10m": [18.0, 360.0, 7.2, 10.8, 36.0],
+            "winddirection_10m": [0.0, 270.0, 170.0, 180.0, 10.0],
+            "surface_pressure": [990.0, 800.0, 1011.0, 1012.0, 989.0],
+            "windgusts_10m": [50.4, 360.0, 14.4, 18.0, 72.0],
+        },
+        "current": {
+            "windspeed": 180.0,
+            "winddirection": 270.0,
+            "pressure": 777.0,
+        },
+    }
+
+
+def _build_aligned_forecast_messages() -> tuple[str, str, list[tuple[str, date]]]:
+    region_weather = _forecast_payload(
+        today_high=29.0,
+        today_low=22.0,
+        tomorrow_high=42.0,
+        tomorrow_low=31.0,
+    )
+    city_weather = {
+        (1.0, 2.0): _forecast_payload(
+            today_high=28.0,
+            today_low=23.0,
+            tomorrow_high=40.0,
+            tomorrow_low=30.0,
+        ),
+        (3.0, 4.0): _forecast_payload(
+            today_high=29.0,
+            today_low=24.0,
+            tomorrow_high=42.0,
+            tomorrow_low=31.0,
+        ),
+    }
+    context_calls: list[tuple[str, date]] = []
+
+    def fake_get_weather(lat, lon, *args, **kwargs):
+        del args, kwargs
+        if (lat, lon) == (post_common_module.CY_LAT, post_common_module.CY_LON):
+            return region_weather
+        return city_weather[(float(lat), float(lon))]
+
+    def fake_visibility_context(_weather, *, post_type, target_date, **_kwargs):
+        context_calls.append((post_type, target_date))
+        return types.SimpleNamespace()
+
+    def fake_storm_today(*_args, **_kwargs):
+        context_calls.append(("storm_morning", date(2026, 8, 9)))
+        return {"warning": False}
+
+    def fake_storm_tomorrow(*_args, **_kwargs):
+        context_calls.append(("storm_evening", date(2026, 8, 10)))
+        return {"warning": False}
+
+    replacements = {
+        "get_weather": fake_get_weather,
+        "get_fact": lambda *_args, **_kwargs: "",
+        "storm_flags_for_today": fake_storm_today,
+        "storm_flags_for_tomorrow": fake_storm_tomorrow,
+        "get_air": lambda *_args, **_kwargs: {},
+        "get_cyprus_visibility_context": fake_visibility_context,
+        "build_cyprus_visibility_line": lambda *_args, **_kwargs: None,
+        "save_cyprus_visibility_diagnostics": lambda *_args, **_kwargs: None,
+        "sun_line_for_mode": lambda *_args, **_kwargs: None,
+        "_morning_combo_air_radiation_pollen": lambda *_args, **_kwargs: None,
+        "_air_by_city_line": lambda *_args, **_kwargs: None,
+        "_cyprus_quake_line_for_morning": lambda *_args, **_kwargs: None,
+        "get_solar_wind": lambda *_args, **_kwargs: {},
+        "get_sst_cached": lambda *_args, **_kwargs: 27.0,
+        "_water_highlights": lambda *_args, **_kwargs: None,
+        "build_astro_section": lambda *_args, **_kwargs: "",
+        "USE_WORLD_KP": False,
+    }
+
+    def build() -> tuple[str, str, list[tuple[str, date]]]:
+        tz_obj = types.SimpleNamespace(name="Asia/Nicosia")
+        morning = post_common_module.build_message(
+            region_name="Кипр",
+            sea_label="Морские города",
+            sea_cities=[("Limassol", (1.0, 2.0))],
+            other_label="Континентальные города",
+            other_cities=[("Nicosia", (3.0, 4.0))],
+            tz=tz_obj,
+            mode="morning",
+        )
+        evening = post_common_module.build_message(
+            region_name="Кипр",
+            sea_label="Морские города",
+            sea_cities=[("Limassol", (1.0, 2.0))],
+            other_label="Континентальные города",
+            other_cities=[("Nicosia", (3.0, 4.0))],
+            tz=tz_obj,
+            mode="evening",
+        )
+        return morning, evening, context_calls
+
+    return _with_forecast_clock(
+        lambda: _replace_attrs(post_common_module, replacements, build)
+    )
+
+
+def cy_morning_uses_today_for_raw_format_score_feels_and_plan() -> None:
+    raw_morning, _raw_evening, context_calls = _build_aligned_forecast_messages()
+    assert "погода на сегодня (09.08.2026)" in raw_morning
+    assert "Теплее всего — Никосия (29°)" in raw_morning
+    assert "прохладнее — Лимассол (28°)" in raw_morning
+    assert "<b>Лимассол</b>: 28/23 °C" in raw_morning
+    assert "☀️ ясно" in raw_morning
+    assert "💨 3.0 м/с (Ю) • порывы 5" in raw_morning
+    assert "1012 гПа ↑" in raw_morning
+    assert "🌊 27" in raw_morning
+    assert "УФ-индекс 9 (Very High)" in raw_morning
+    assert "40/30" not in raw_morning
+    assert "42/31" not in raw_morning
+    assert "порывы 20" not in raw_morning
+    assert ("morning", date(2026, 8, 9)) in context_calls
+    assert ("storm_morning", date(2026, 8, 9)) in context_calls
+
+    formatted = build_morning_format_v2("Кипр", raw_morning)
+    assert "🌡 Теплее всего — Никосия (29°), прохладнее — Лимассол (28°)" in formatted
+    assert "40/30" not in formatted and "42/31" not in formatted
+
+    score = _cyprus_score_line(formatted)
+    feels = _cyprus_feels_line(formatted)
+    plan = _cyprus_smart_plan_line(formatted)
+    assert "сильная жара" not in score and "жара" not in score
+    assert "очень тепло в Никосии" in feels and "жарко" not in feels
+    assert plan == "✅ План: SPF 50, вода с собой; полдень провести в тени; прогулка утром или ближе к закату."
+
+
+def cy_evening_keeps_tomorrow_city_forecast() -> None:
+    _raw_morning, raw_evening, context_calls = _build_aligned_forecast_messages()
+    assert "погода на завтра (10.08.2026)" in raw_evening
+    assert "<b>Лимассол</b>: 40/30 °C" in raw_evening
+    assert "<b>Никосия</b>: 42/31 °C" in raw_evening
+    assert "⛈ гроза" in raw_evening
+    assert "💨 10.0 м/с (С) • порывы 20" in raw_evening
+    assert "989 гПа ↓" in raw_evening
+    assert ("evening", date(2026, 8, 10)) in context_calls
+
+
+def cy_city_forecast_omits_row_when_target_daily_date_is_missing() -> None:
+    payload = {
+        "daily": {
+            "time": ["2026-08-10"],
+            "temperature_2m_max": [40.0],
+            "temperature_2m_min": [30.0],
+            "weathercode": [95],
+        },
+        "hourly": {
+            "time": ["2026-08-10T12:00"],
+            "windspeed_10m": [36.0],
+            "surface_pressure": [989.0],
+            "windgusts_10m": [72.0],
+        },
+        "current": {"temperature": 35.0, "windspeed": 180.0, "pressure": 777.0},
+    }
+
+    def run() -> None:
+        result = _replace_attrs(
+            post_common_module,
+            {"get_weather": lambda *_args, **_kwargs: payload},
+            lambda: post_common_module._city_detail_line(
+                "Limassol",
+                1.0,
+                2.0,
+                types.SimpleNamespace(name="Asia/Nicosia"),
+                include_sst=False,
+                target_date=date(2026, 8, 9),
+            ),
+        )
+        assert result == (None, None)
+
+    _with_forecast_clock(run)
+
+
+def cy_city_forecast_does_not_shift_incomplete_or_malformed_arrays() -> None:
+    payload = {
+        "daily": {
+            "time": ["bad-daily-time", "2026-08-09"],
+            "temperature_2m_max": [99.0, 29.0],
+            "temperature_2m_min": [18.0],
+            "weathercode": [95, 0],
+        },
+        "hourly": {
+            "time": ["bad-hourly-time", "2026-08-09T12:00"],
+            "windspeed_10m": [360.0, 10.8],
+            "winddirection_10m": [270.0],
+            "surface_pressure": [800.0, 1012.0],
+            "windgusts_10m": [360.0, 18.0],
+        },
+    }
+
+    def run() -> None:
+        _tmax, line = _replace_attrs(
+            post_common_module,
+            {"get_weather": lambda *_args, **_kwargs: payload},
+            lambda: post_common_module._city_detail_line(
+                "Limassol",
+                1.0,
+                2.0,
+                types.SimpleNamespace(name="Asia/Nicosia"),
+                include_sst=False,
+                target_date=date(2026, 8, 9),
+            ),
+        )
+        assert line is not None
+        assert "29 °C" in line and "29/18" not in line
+        assert "☀️ ясно" in line and "⛈ гроза" not in line
+        assert "💨 3.0 м/с" in line and "270" not in line
+        assert "порывы 5" in line and "порывы 100" not in line
+        assert "1012 гПа" in line and "800 гПа" not in line
+
+    _with_forecast_clock(run)
+
+
+def cy_city_forecast_never_uses_current_for_missing_target_hourly_date() -> None:
+    payload = {
+        "daily": {
+            "time": ["2026-08-09"],
+            "temperature_2m_max": [29.0],
+            "temperature_2m_min": [23.0],
+            "weathercode": [0],
+        },
+        "hourly": {
+            "time": ["2026-08-10T12:00"],
+            "windspeed_10m": [36.0],
+            "surface_pressure": [989.0],
+            "windgusts_10m": [72.0],
+        },
+        "current": {"windspeed": 180.0, "winddirection": 270.0, "pressure": 777.0},
+    }
+
+    def run() -> None:
+        _tmax, line = _replace_attrs(
+            post_common_module,
+            {"get_weather": lambda *_args, **_kwargs: payload},
+            lambda: post_common_module._city_detail_line(
+                "Limassol",
+                1.0,
+                2.0,
+                types.SimpleNamespace(name="Asia/Nicosia"),
+                include_sst=False,
+                target_date=date(2026, 8, 9),
+            ),
+        )
+        assert line == "<b>Лимассол</b>: 29/23 °C • ☀️ ясно"
+        assert "180.0" not in line and "777" not in line and "10.0 м/с" not in line
+
+    _with_forecast_clock(run)
 
 
 def cy_morning_averages_coastal_sea_rows() -> None:
@@ -2095,6 +2445,11 @@ def main() -> None:
     checks = (
         cy_morning_adds_concise_sea_block_when_available,
         cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening,
+        cy_morning_uses_today_for_raw_format_score_feels_and_plan,
+        cy_evening_keeps_tomorrow_city_forecast,
+        cy_city_forecast_omits_row_when_target_daily_date_is_missing,
+        cy_city_forecast_does_not_shift_incomplete_or_malformed_arrays,
+        cy_city_forecast_never_uses_current_for_missing_target_hourly_date,
         cy_morning_averages_coastal_sea_rows,
         cy_morning_adds_sea_fallback_when_unavailable,
         cy_morning_rejects_non_marine_numbers_for_sea,


### PR DESCRIPTION
## What changed

- Align Cyprus morning city temperatures, weather code, wind, gusts, and pressure to the exact local date shown in the morning title.
- Preserve tomorrow semantics for evening city forecasts and keep SST as the current sea observation.
- Fail closed when the target daily/hourly date is missing instead of borrowing another day or current conditions.
- Add regressions for strongly different today/tomorrow fixtures, malformed and incomplete arrays, missing target dates, and downstream FORMAT_V2 scoring, feels, and smart-plan behavior.

## Root cause

The shared city formatter always used tomorrow helpers and fixed forecast positions even when called by the morning post.

## Validation

- 253 offline checks passed (248 existing + 5 new) with socket connections blocked.
- Existing CI compileall set passed.
- `git diff --check` passed.
- Diff is limited to `post_common.py` and `tools/test_format_v2_morning_cy.py`.