### PR TITLE
Fix Cyprus evening water-sport forecast fallback

### DIFF
--- a/post_common.py
+++ b/post_common.py
@@ -1263,94 +1263,12 @@ def _circular_mean_deg(deg_list: List[float]) -> Optional[float]:
 def pick_tomorrow_header_metrics(
     wm: Dict[str, Any], tz: pendulum.Timezone
 ) -> Tuple[Optional[float], Optional[int], Optional[int], str]:
-    hourly = wm.get("hourly") or {}
-    times = _hourly_times(wm)
-
-    # FIX: используем today() вместо now(), чтобы WORK_DATE (pendulum.today monkeypatch) влиял корректно
     tomorrow = pendulum.today(tz).add(days=1).date()
-
-    spd_arr = _pick(
-        hourly,
-        "windspeed_10m",
-        "windspeed",
-        "wind_speed_10m",
-        "wind_speed",
-        default=[],
+    wind_ms, wind_dir, press_val, trend, _gust_ms = _city_header_metrics_for_date(
+        wm,
+        tz,
+        tomorrow,
     )
-    dir_arr = _pick(
-        hourly,
-        "winddirection_10m",
-        "winddirection",
-        "wind_dir_10m",
-        "wind_dir",
-        default=[],
-    )
-    prs_arr = hourly.get("surface_pressure", []) or hourly.get("pressure", [])
-    if times:
-        idx_noon = _nearest_index_for_day(times, tomorrow, 12, tz)
-        idx_morn = _nearest_index_for_day(times, tomorrow, 6, tz)
-    else:
-        idx_noon = idx_morn = None
-    wind_ms = wind_dir = press_val = None
-    trend = "→"
-    if idx_noon is not None:
-        try:
-            spd = float(spd_arr[idx_noon]) if idx_noon < len(spd_arr) else None
-        except Exception:
-            spd = None
-        try:
-            wdir = float(dir_arr[idx_noon]) if idx_noon < len(dir_arr) else None
-        except Exception:
-            wdir = None
-        try:
-            p_noon = float(prs_arr[idx_noon]) if idx_noon < len(prs_arr) else None
-        except Exception:
-            p_noon = None
-        try:
-            p_morn = (
-                float(prs_arr[idx_morn])
-                if idx_morn is not None and idx_morn < len(prs_arr)
-                else None
-            )
-        except Exception:
-            p_morn = None
-        wind_ms = kmh_to_ms(spd) if isinstance(spd, (int, float)) else None
-        wind_dir = int(round(wdir)) if isinstance(wdir, (int, float)) else None
-        press_val = int(round(p_noon)) if isinstance(p_noon, (int, float)) else None
-        if isinstance(p_noon, (int, float)) and isinstance(p_morn, (int, float)):
-            diff = p_noon - p_morn
-            trend = "↑" if diff >= 0.3 else "↓" if diff <= -0.3 else "→"
-    if wind_ms is None and times:
-        idxs = [i for i, t in enumerate(times) if t.in_tz(tz).date() == tomorrow]
-        if idxs:
-            try:
-                speeds = [float(spd_arr[i]) for i in idxs if i < len(spd_arr)]
-            except Exception:
-                speeds = []
-            try:
-                dirs = [float(dir_arr[i]) for i in idxs if i < len(dir_arr)]
-            except Exception:
-                dirs = []
-            try:
-                prs = [float(prs_arr[i]) for i in idxs if i < len(prs_arr)]
-            except Exception:
-                prs = []
-            if speeds:
-                wind_ms = kmh_to_ms(sum(speeds) / len(speeds))
-            mean_dir = _circular_mean_deg(dirs)
-            wind_dir = int(round(mean_dir)) if mean_dir is not None else wind_dir
-            if prs:
-                press_val = int(round(sum(prs) / len(prs)))
-    if wind_ms is None or wind_dir is None or press_val is None:
-        cur = wm.get("current") or {}
-        if wind_ms is None:
-            spd = cur.get("windspeed") or cur.get("wind_speed")
-            wind_ms = kmh_to_ms(spd) if isinstance(spd, (int, float)) else wind_ms
-        if wind_dir is None:
-            wdir = cur.get("winddirection") or cur.get("wind_dir")
-            wind_dir = int(round(float(wdir))) if isinstance(wdir, (int, float)) else wind_dir
-        if press_val is None and isinstance(cur.get("pressure"), (int, float)):
-            press_val = int(round(float(cur["pressure"])))
     return wind_ms, wind_dir, press_val, trend
 
 
@@ -2230,7 +2148,6 @@ def _morning_sea_city_lines(
 
 def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone) -> Optional[str]:
     wm = get_weather(la, lo) or {}
-    wind_ms, wind_dir, _, _ = pick_tomorrow_header_metrics(wm, tz_obj)
     target_date = pendulum.today(tz_obj).add(days=1).date()
     wave_h, _, wave_at = _fetch_wave_for_tomorrow(
         la,
@@ -2239,31 +2156,17 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
         prefer_hour=SUP_TARGET_HOUR,
         target_date=target_date,
     )
-
-    def _gust_at_noon(wm0: Dict[str, Any], tz0: pendulum.Timezone) -> Optional[float]:
-        hourly = wm0.get("hourly") or {}
-        times = _hourly_times(wm0)
-
-        # FIX: today() вместо now() — консистентность с WORK_DATE
-        tom = pendulum.today(tz0).add(days=1).date()
-
-        idx = _nearest_index_for_day(times, tom, 12, tz0)
-        arr = _pick(hourly, "windgusts_10m", "wind_gusts_10m", "wind_gusts", default=[])
-        if idx is not None and idx < len(arr):
-            try:
-                return kmh_to_ms(float(arr[idx]))
-            except Exception:
-                return None
-        return None
-
-    gust = _gust_at_noon(wm, tz_obj)
+    activity_sample = _sup_weather_sample(wm, tz_obj, target_date)
+    wind_ms = activity_sample.get("wind_ms")
+    gust = activity_sample.get("gust_ms")
+    wind_dir = activity_sample.get("wind_dir")
     sst = get_sst_cached(la, lo)
     wind_val = float(wind_ms) if isinstance(wind_ms, (int, float)) else None
     gust_val = float(gust) if isinstance(gust, (int, float)) else None
     card = _cardinal(float(wind_dir)) if isinstance(wind_dir, (int, float)) else None
     shore, shore_src = _shore_class(city, float(wind_dir) if isinstance(wind_dir, (int, float)) else None)
 
-    sup_sample = _sup_weather_sample(wm, tz_obj, target_date)
+    sup_sample = activity_sample
     sup_wind = sup_sample.get("wind_ms")
     sup_gust = sup_sample.get("gust_ms")
     sup_dir = sup_sample.get("wind_dir")
@@ -2286,7 +2189,10 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
     )
 
     kite_good = False
-    if wind_val is not None:
+    kite_evidence_complete = all(
+        value is not None for value in (wind_val, gust_val, wind_dir, shore)
+    )
+    if kite_evidence_complete:
         if KITE_WIND_GOOD_MIN <= wind_val <= KITE_WIND_GOOD_MAX:
             kite_good = True
         if shore == "offshore":

--- a/post_common.py
+++ b/post_common.py
@@ -2205,7 +2205,7 @@ def _water_highlights(city: str, la: float, lo: float, tz_obj: pendulum.Timezone
     surf_good = False
     if wave_h is not None:
         if SURF_WAVE_GOOD_MIN <= wave_h <= SURF_WAVE_GOOD_MAX and (
-            wind_val is None or wind_val <= SURF_WIND_MAX
+            wind_val is not None and wind_val <= SURF_WIND_MAX
         ):
             surf_good = True
 

--- a/tools/test_sup_safety_cy.py
+++ b/tools/test_sup_safety_cy.py
@@ -486,6 +486,26 @@ def safe_surf_and_sup_recommendations_preserve_existing_behavior() -> None:
     assert "Сёрф" not in sup
 
 
+def missing_or_malformed_tomorrow_wind_is_fail_closed_for_surf() -> None:
+    for noon_wind in (None, "not-a-number"):
+        payload = _tomorrow_weather(
+            times=[
+                "2026-08-10T06:00",
+                "2026-08-10T12:00",
+                "2026-08-10T18:00",
+            ],
+            wind_kmh=[54.0, noon_wind, 54.0],
+            gust_kmh=[57.6, 25.2, 57.6],
+            wind_dir=[180.0, 180.0, 180.0],
+            current={"windspeed": 3.6, "winddirection": 180.0},
+        )
+        sample = _with_forecast_clock(
+            lambda: _sup_weather_sample(payload, TZ, TARGET_DATE)
+        )
+        assert sample["wind_ms"] is None
+        assert "Отлично: Сёрф" not in _water_line(payload, wave_h=1.2)
+
+
 CHECKS = [
     calm_onshore_is_excellent,
     calm_cross_shore_is_excellent,
@@ -508,6 +528,7 @@ CHECKS = [
     malformed_timestamp_keeps_weather_arrays_at_original_indices,
     current_sentinels_do_not_change_final_evening_format_v2,
     safe_surf_and_sup_recommendations_preserve_existing_behavior,
+    missing_or_malformed_tomorrow_wind_is_fail_closed_for_surf,
 ]
 
 

--- a/tools/test_sup_safety_cy.py
+++ b/tools/test_sup_safety_cy.py
@@ -94,11 +94,15 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+import post_common as post_common_module  # noqa: E402
+from format_v2 import build_evening_format_v2  # noqa: E402
 from post_common import (  # noqa: E402
     _shore_class,
     _sup_guidance_line,
     _sup_samples_are_aligned,
     _sup_weather_sample,
+    _water_highlights,
+    pick_tomorrow_header_metrics,
     sup_safety_level,
 )
 from post_safety import sanitize_post_text  # noqa: E402
@@ -107,6 +111,78 @@ from safe_test_post import _downgrade_sup_lines, _sup_guard_line, _translate_sho
 
 TZ = pendulum.timezone("Asia/Nicosia")
 TARGET_DATE = pendulum.date(2026, 8, 10)
+
+
+def _replace_attrs(obj, replacements: dict, callback):
+    old = {name: getattr(obj, name) for name in replacements}
+    try:
+        for name, value in replacements.items():
+            setattr(obj, name, value)
+        return callback()
+    finally:
+        for name, value in old.items():
+            setattr(obj, name, value)
+
+
+def _with_forecast_clock(callback):
+    fixed_today = pendulum.datetime(2026, 8, 9, 9, 0, tz=TZ)
+    return _replace_attrs(
+        post_common_module.pendulum,
+        {"today": lambda _tz=None: fixed_today},
+        callback,
+    )
+
+
+def _water_line(payload: dict, *, wave_h: float = 0.3) -> str:
+    wave_at = pendulum.datetime(2026, 8, 10, 12, 0, tz=TZ)
+
+    def build() -> str:
+        return _replace_attrs(
+            post_common_module,
+            {
+                "get_weather": lambda *_args, **_kwargs: payload,
+                "_fetch_wave_for_tomorrow": lambda *_args, **_kwargs: (wave_h, None, wave_at),
+                "get_sst_cached": lambda *_args, **_kwargs: 27.0,
+            },
+            lambda: _water_highlights("Limassol", 34.707, 33.022, TZ) or "",
+        )
+
+    return _with_forecast_clock(build)
+
+
+def _tomorrow_weather(
+    *,
+    times: list[str] | None = None,
+    wind_kmh: list[float | None] | None = None,
+    gust_kmh: list[float | None] | None = None,
+    wind_dir: list[float | None] | None = None,
+    pressure: list[float | None] | None = None,
+    current: dict | None = None,
+) -> dict:
+    return {
+        "hourly": {
+            "time": times if times is not None else ["2026-08-10T12:00"],
+            "windspeed_10m": wind_kmh if wind_kmh is not None else [28.8],
+            "windgusts_10m": gust_kmh if gust_kmh is not None else [32.4],
+            "winddirection_10m": wind_dir if wind_dir is not None else [180.0],
+            "surface_pressure": pressure if pressure is not None else [1012.0],
+        },
+        "current": current or {},
+    }
+
+
+def _final_evening_text(payload: dict) -> str:
+    highlight = _water_line(payload)
+    raw_lines = [
+        "<b>Кипр: погода на завтра (10.08.2026)</b>",
+        "🏖 <b>Морские города</b>",
+        "😎 <b>Лимассол</b>: 30/24 °C • 💨 3.0 м/с (Ю) • порывы 7",
+    ]
+    if highlight:
+        raw_lines.append("   " + highlight)
+    raw_lines.extend(("———", "#Кипр #погода #здоровье"))
+    legacy_safe = sanitize_post_text("\n".join(raw_lines)).text
+    return sanitize_post_text(build_evening_format_v2("Кипр", legacy_safe)).text
 
 
 def _weather(
@@ -286,6 +362,130 @@ def format_v2_guard_rejects_partial_evidence_without_touching_other_sports() -> 
     assert "данных для уверенной оценки недостаточно" in guarded
 
 
+def tomorrow_hourly_builds_existing_kite_recommendation() -> None:
+    payload = _tomorrow_weather(
+        times=["2026-08-10T06:00", "2026-08-10T12:00"],
+        wind_kmh=[18.0, 28.8],
+        gust_kmh=[25.2, 32.4],
+        wind_dir=[180.0, 180.0],
+        pressure=[1010.0, 1012.0],
+    )
+    metrics = _with_forecast_clock(lambda: pick_tomorrow_header_metrics(payload, TZ))
+    assert round(metrics[0], 1) == 8.0
+    assert metrics[1:] == (180, 1012, "↑")
+    line = _water_line(payload)
+    assert "Отлично: Кайт/Винг/Винд" in line
+    assert "S/onshore" in line
+
+
+def current_only_never_builds_positive_water_recommendation() -> None:
+    payload = {
+        "current": {
+            "windspeed": 28.8,
+            "wind_gusts_10m": 32.4,
+            "winddirection": 180.0,
+            "pressure": 777.0,
+        }
+    }
+    assert _with_forecast_clock(lambda: pick_tomorrow_header_metrics(payload, TZ)) == (
+        None,
+        None,
+        None,
+        "→",
+    )
+    assert "Отлично: Кайт/Винг/Винд" not in _water_line(payload)
+
+
+def today_hourly_plus_current_never_builds_positive_water_recommendation() -> None:
+    payload = _tomorrow_weather(
+        times=["2026-08-09T12:00"],
+        wind_kmh=[28.8],
+        gust_kmh=[32.4],
+        wind_dir=[180.0],
+        pressure=[1012.0],
+        current={
+            "windspeed": 28.8,
+            "wind_gusts_10m": 32.4,
+            "winddirection": 180.0,
+            "pressure": 777.0,
+        },
+    )
+    assert _with_forecast_clock(lambda: pick_tomorrow_header_metrics(payload, TZ)) == (
+        None,
+        None,
+        None,
+        "→",
+    )
+    assert "Отлично: Кайт/Винг/Винд" not in _water_line(payload)
+
+
+def missing_tomorrow_direction_or_gust_is_fail_closed_for_kite() -> None:
+    missing_direction = _tomorrow_weather(wind_dir=[])
+    missing_gust = _tomorrow_weather(gust_kmh=[])
+    assert "Отлично: Кайт/Винг/Винд" not in _water_line(missing_direction)
+    assert "Отлично: Кайт/Винг/Винд" not in _water_line(missing_gust)
+
+
+def malformed_timestamp_keeps_weather_arrays_at_original_indices() -> None:
+    payload = _tomorrow_weather(
+        times=["not-a-time", "2026-08-10T12:00"],
+        wind_kmh=[36.0, 28.8],
+        gust_kmh=[72.0, 32.4],
+        wind_dir=[0.0, 180.0],
+        pressure=[777.0, 1012.0],
+    )
+    metrics = _with_forecast_clock(lambda: pick_tomorrow_header_metrics(payload, TZ))
+    assert round(metrics[0], 1) == 8.0
+    assert metrics[1] == 180
+    assert metrics[2] == 1012
+    line = _water_line(payload)
+    assert "Отлично: Кайт/Винг/Винд" in line
+    assert "S/onshore" in line
+    assert "N/offshore" not in line
+
+
+def current_sentinels_do_not_change_final_evening_format_v2() -> None:
+    today_hourly = {
+        "time": ["2026-08-09T12:00"],
+        "windspeed_10m": [3.6],
+        "windgusts_10m": [7.2],
+        "winddirection_10m": [0.0],
+        "surface_pressure": [1000.0],
+    }
+    without_current = {"hourly": today_hourly, "current": {}}
+    with_current = {
+        "hourly": today_hourly,
+        "current": {
+            "windspeed": 28.8,
+            "wind_gusts_10m": 32.4,
+            "winddirection": 180.0,
+            "pressure": 777.0,
+        },
+    }
+    baseline = _final_evening_text(without_current)
+    sentinel = _final_evening_text(with_current)
+    assert sentinel == baseline
+    assert "Кайт/Винг/Винд" not in sentinel
+    assert "777 гПа" not in sentinel
+
+
+def safe_surf_and_sup_recommendations_preserve_existing_behavior() -> None:
+    safe_weather = _tomorrow_weather(
+        wind_kmh=[10.8],
+        gust_kmh=[25.2],
+        wind_dir=[180.0],
+    )
+    surf = _water_line(safe_weather, wave_h=1.2)
+    assert "Отлично: Сёрф" in surf
+    assert "Кайт/Винг/Винд" not in surf
+    assert "Отлично: SUP" not in surf
+
+    sup = _water_line(safe_weather, wave_h=0.3)
+    assert "Отлично: SUP" in sup
+    assert "Кайт/Винг/Винд" not in sup
+    assert "Сёрф" not in sup
+
+
 CHECKS = [
     calm_onshore_is_excellent,
     calm_cross_shore_is_excellent,
@@ -301,6 +501,13 @@ CHECKS = [
     format_v2_guard_uses_sup_period_not_previous_city_gust,
     format_v2_guard_cannot_upgrade_or_hide_unsafe_sup,
     format_v2_guard_rejects_partial_evidence_without_touching_other_sports,
+    tomorrow_hourly_builds_existing_kite_recommendation,
+    current_only_never_builds_positive_water_recommendation,
+    today_hourly_plus_current_never_builds_positive_water_recommendation,
+    missing_tomorrow_direction_or_gust_is_fail_closed_for_kite,
+    malformed_timestamp_keeps_weather_arrays_at_original_indices,
+    current_sentinels_do_not_change_final_evening_format_v2,
+    safe_surf_and_sup_recommendations_preserve_existing_behavior,
 ]
 
 


### PR DESCRIPTION
## What changed

- Make `pick_tomorrow_header_metrics()` use only hourly values aligned to the exact tomorrow date.
- Make evening Kite/Surf guidance use one aligned tomorrow weather row without falling back to `current` observations or another day.
- Require complete tomorrow wind, gust, direction, and shore evidence before publishing a positive Kite/Wing/Windsurf recommendation.
- Preserve existing thresholds, wording, Surf behavior, and the strict SUP safety path.

## Root cause

The legacy evening water-sport path compressed malformed timestamps and independently fell back to `current` wind and direction when tomorrow hourly data was missing. That could publish a positive recommendation for tomorrow from today's observation.

## Validation

- 267/267 offline checks passed with socket connections blocked (260 existing + 7 new).
- Existing CI `compileall` set passed.
- `git diff --check` passed.
- Diff is limited to `post_common.py` and `tools/test_sup_safety_cy.py`.