### PR TITLE
Fix Cyprus weekly island coverage

### DIFF
--- a/send_weekly_forecast.py
+++ b/send_weekly_forecast.py
@@ -14,16 +14,12 @@ from pathlib import Path
 from typing import Any
 
 from editorial_voice import build_weekly_meaning
+from settings_cy import INLAND_CITIES, MARINE_CITIES
 
 REGION_NAME = "Кипр"
 TZ_STR = os.getenv("TZ", "Asia/Nicosia")
-PRIMARY_COORDS = (34.707, 33.022)
-SEA_POINTS = [
-    ("Лимассол", (34.707, 33.022)),
-    ("Пафос", (34.776, 32.424)),
-    ("Айя-Напа", (34.988, 34.012)),
-    ("Ларнака", (34.916, 33.624)),
-]
+ISLAND_POINTS = [*MARINE_CITIES.items(), *INLAND_CITIES.items()]
+SEA_POINTS = list(MARINE_CITIES.items())
 HASHTAGS = "#Кипр #вайбнедели #погода #море #астропогода"
 
 MONTHS_RU = {
@@ -97,17 +93,24 @@ def _load_json(path: Path) -> Any:
 def _fetch_weather() -> dict[str, Any]:
     try:
         from weather import get_weather  # type: ignore
-
-        return get_weather(*PRIMARY_COORDS) or {}
     except Exception:
         return {}
+    out: dict[str, Any] = {}
+    for city, coords in ISLAND_POINTS:
+        try:
+            payload = get_weather(*coords) or {}
+        except Exception:
+            payload = {}
+        if isinstance(payload, dict) and payload:
+            out[city] = payload
+    return out
 
 
 def _fetch_air() -> dict[str, Any]:
     try:
-        from air import get_air  # type: ignore
+        from air import get_air_for_cities  # type: ignore
 
-        return get_air(*PRIMARY_COORDS) or {}
+        return get_air_for_cities(ISLAND_POINTS) or {}
     except Exception:
         return {}
 
@@ -205,6 +208,39 @@ def _weather_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "rain": any((x or 0) >= 40 for x in rain_prob if x is not None)
         or any(int(x) in RAIN_CODES for x in codes if x is not None),
     }
+
+
+def _weather_payloads(weather_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(weather_payload, dict):
+        return []
+    if isinstance(weather_payload.get("daily"), dict):
+        return [weather_payload]
+    return [value for value in weather_payload.values() if isinstance(value, dict)]
+
+
+def _weather_metrics_for_payload(weather_payload: dict[str, Any], start: date) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for payload in _weather_payloads(weather_payload):
+        rows.extend(_daily_rows(payload, start))
+    return _weather_metrics(rows)
+
+
+def _aggregate_air_data(air_data: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(air_data, dict):
+        return {}
+    if any(key in air_data for key in ("aqi", "pm25", "pm10")):
+        return air_data
+    aggregated: dict[str, Any] = {}
+    for key in ("aqi", "pm25", "pm10"):
+        values = [
+            _num(city_data.get(key))
+            for city_data in air_data.values()
+            if isinstance(city_data, dict)
+        ]
+        available = [value for value in values if value is not None]
+        if available:
+            aggregated[key] = max(available)
+    return aggregated
 
 
 def _main_background(metrics: dict[str, Any]) -> str:
@@ -427,9 +463,8 @@ def build_weekly_forecast(
     lunar_data = lunar_data if lunar_data is not None else _load_lunar_calendar()
     astro_events = _load_astro_events(start, astro_events_paths)
 
-    rows = _daily_rows(weather_payload or {}, start)
-    metrics = _weather_metrics(rows)
-    air, poor_air = _air_line(air_data or {})
+    metrics = _weather_metrics_for_payload(weather_payload or {}, start)
+    air, poor_air = _air_line(_aggregate_air_data(air_data or {}))
     space, elevated_kp = _space_line(kp_tuple)
     lunar = _lunar_lines(start, lunar_data, astro_events)
     plan = _plan_lines(metrics, poor_air, elevated_kp, lunar)

--- a/tools/test_weekly_forecast.py
+++ b/tools/test_weekly_forecast.py
@@ -9,12 +9,19 @@ import tempfile
 from datetime import date
 from html.parser import HTMLParser
 from pathlib import Path
+from types import ModuleType
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from send_weekly_forecast import build_weekly_forecast  # noqa: E402
+from send_weekly_forecast import (  # noqa: E402
+    _aggregate_air_data,
+    _fetch_air,
+    _fetch_weather,
+    _weather_metrics_for_payload,
+    build_weekly_forecast,
+)
 
 
 WEATHER = {
@@ -57,10 +64,31 @@ LUNAR = {
 }
 
 FORBIDDEN = ("аварии", "чрезвычайные ситуации", "операции лучше отложить", "воздушном пространстве")
+EXPECTED_ISLAND_POINTS = [
+    ("Limassol", (34.707, 33.022)),
+    ("Pafos", (34.776, 32.424)),
+    ("Ayia Napa", (34.988, 34.012)),
+    ("Larnaca", (34.916, 33.624)),
+    ("Nicosia", (35.170, 33.360)),
+    ("Troodos", (34.916, 32.823)),
+]
 
 
 class _Parser(HTMLParser):
     pass
+
+
+def _with_module(name: str, module: ModuleType, callback):
+    missing = object()
+    previous = sys.modules.get(name, missing)
+    try:
+        sys.modules[name] = module
+        return callback()
+    finally:
+        if previous is missing:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
 
 
 def _base_text(extra_paths: list[Path] | None = None) -> str:
@@ -148,11 +176,87 @@ def test_weekly_forecast_keeps_stronger_kite_warning_for_high_gusts() -> None:
     assert text.splitlines()[-1] == "#Кипр #вайбнедели #погода #море #астропогода"
 
 
+def test_weekly_weather_fetches_exact_island_points() -> None:
+    calls: list[tuple[float, float]] = []
+
+    def fake_get_weather(lat: float, lon: float) -> dict:
+        calls.append((lat, lon))
+        return WEATHER
+
+    weather_module = ModuleType("weather")
+    weather_module.get_weather = fake_get_weather
+    payload = _with_module("weather", weather_module, _fetch_weather)
+    assert calls == [coords for _city, coords in EXPECTED_ISLAND_POINTS]
+    assert list(payload) == [city for city, _coords in EXPECTED_ISLAND_POINTS]
+
+
+def test_weekly_weather_preserves_island_extremes() -> None:
+    def city_weather(*, tmax=30, tmin=22, wind=5, gust=8, uv=5, rain=0, code=0) -> dict:
+        return {
+            "daily": {
+                "time": [f"2026-07-{day:02d}" for day in range(1, 8)],
+                "temperature_2m_max": [tmax] * 7,
+                "temperature_2m_min": [tmin] * 7,
+                "wind_speed_10m_max": [wind] * 7,
+                "wind_gusts_10m_max": [gust] * 7,
+                "precipitation_probability_max": [rain] * 7,
+                "weathercode": [code] * 7,
+                "uv_index_max": [uv] * 7,
+            }
+        }
+
+    payload = {
+        "Limassol": city_weather(tmax=41),
+        "Pafos": city_weather(tmin=16),
+        "Ayia Napa": city_weather(wind=17),
+        "Larnaca": city_weather(gust=24),
+        "Nicosia": city_weather(uv=12),
+        "Troodos": city_weather(code=61),
+    }
+    metrics = _weather_metrics_for_payload(payload, date(2026, 7, 1))
+    assert metrics["tmax_max"] == 41
+    assert metrics["tmin_min"] == 16
+    assert metrics["wind_max"] == 17
+    assert metrics["gust_max"] == 24
+    assert metrics["uv_max"] == 12
+    assert metrics["rain"] is True
+
+
+def test_weekly_air_fetches_exact_island_points() -> None:
+    calls: list[list[tuple[str, tuple[float, float]]]] = []
+
+    def fake_get_air_for_cities(points):
+        calls.append(list(points))
+        return {"Limassol": AIR}
+
+    air_module = ModuleType("air")
+    air_module.get_air_for_cities = fake_get_air_for_cities
+    payload = _with_module("air", air_module, _fetch_air)
+    assert calls == [EXPECTED_ISLAND_POINTS]
+    assert payload == {"Limassol": AIR}
+
+
+def test_weekly_air_preserves_worst_island_values() -> None:
+    aggregated = _aggregate_air_data(
+        {
+            "Limassol": {"aqi": 145, "pm25": 5, "pm10": 8},
+            "Pafos": {"aqi": 20, "pm25": 37, "pm10": 9},
+            "Nicosia": {"aqi": 30, "pm25": 7, "pm10": 91},
+            "Troodos": {"aqi": "н/д", "pm25": None, "pm10": None},
+        }
+    )
+    assert aggregated == {"aqi": 145.0, "pm25": 37.0, "pm10": 91.0}
+
+
 def main() -> None:
     checks = (
         test_weekly_forecast_structure_without_optional_config,
         test_weekly_forecast_includes_curated_astro_events,
         test_weekly_forecast_keeps_stronger_kite_warning_for_high_gusts,
+        test_weekly_weather_fetches_exact_island_points,
+        test_weekly_weather_preserves_island_extremes,
+        test_weekly_air_fetches_exact_island_points,
+        test_weekly_air_preserves_worst_island_values,
     )
     for check in checks:
         check()


### PR DESCRIPTION
## What changed

- Use the existing `MARINE_CITIES` and `INLAND_CITIES` coordinates for all six Cyprus weekly weather points.
- Fetch the weekly weather payload separately for Limassol, Pafos, Ayia Napa, Larnaca, Nicosia, and Troodos through the existing coordinate-aware `get_weather()` path.
- Preserve island extremes without averaging hazards: maximum daytime temperature, UV, wind and gusts; minimum low temperature; and any local rain/WMO rain signal.
- Fetch current air observations through the existing `get_air_for_cities()` path and preserve the worst numeric AQI, PM₂.₅, and PM₁₀ values independently.
- Keep existing single-payload weather and air fixtures compatible.

## Root cause

The Cyprus weekly post used only the Limassol coordinates for both weather and air, even though the output represented the whole island. Regional heat, wind, rain, UV, or pollution outside Limassol could therefore be absent from the weekly assessment.

## Scope

This PR changes only weekly geographic coverage. It does not change pressure fields, daily morning/evening posts, text, thresholds, water-sport logic, visual logic, workflows, lunar/astrology logic, or publication behavior.

The air section still represents current observations; this PR does not turn it into a seven-day air forecast.

## Validation

- 4 new island-coverage regressions passed separately.
- 272/272 offline checks passed across all 12 Cyprus PR suites on exact base `72eda75027b7c8e620b007ff1d50fd44882e93df`.
- External socket connections were blocked during regression execution.
- `python -m compileall` passed for both changed files.
- `git diff --check` passed.
- Diff is limited to `send_weekly_forecast.py` and `tools/test_weekly_forecast.py`.

No manual workflow, Telegram, weather/air/marine/Safecast/image-provider call, or publication was run.