### PR TITLE
Use sea-level pressure for Cyprus forecasts

### DIFF
--- a/format_v2.py
+++ b/format_v2.py
@@ -969,7 +969,7 @@ def _source_wind_pressure_line(date_s: str) -> str:
     spd_arr = _pick(hourly, "windspeed_10m", "windspeed", "wind_speed_10m", "wind_speed") or []
     gust_arr = _pick(hourly, "windgusts_10m", "wind_gusts_10m", "wind_gusts", "windgusts") or []
     dir_arr = _pick(hourly, "winddirection_10m", "winddirection", "wind_dir_10m", "wind_dir", "wind_direction_10m") or []
-    prs_arr = _pick(hourly, "surface_pressure", "pressure_msl", "pressure") or []
+    prs_arr = _pick(hourly, "pressure_msl", "surface_pressure", "pressure") or []
 
     wind_ms = _kmh_to_ms(_value_at(spd_arr, idx_day))
     wind_dir = _value_at(dir_arr, idx_day)

--- a/post_common.py
+++ b/post_common.py
@@ -1826,7 +1826,7 @@ def _city_header_metrics_for_date(
         "wind_dir",
         default=[],
     )
-    pressure_values = _pick(hourly, "surface_pressure", "pressure", default=[])
+    pressure_values = _pick(hourly, "pressure_msl", "surface_pressure", "pressure", default=[])
     gust_values = _pick(
         hourly,
         "windgusts_10m",

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -38,6 +38,7 @@ import cyprus_visual_dedup  # noqa: E402
 import image_prompt_cy_scene as cy_scene_prompt  # noqa: E402
 import post_common as post_common_module  # noqa: E402
 import safe_test_post as safe_module  # noqa: E402
+import utils as utils_module  # noqa: E402
 import weather as weather_module  # noqa: E402
 from image_prompt_cy_scene import build_cyprus_scene_prompt_with_metadata  # noqa: E402
 from post_safety import sanitize_post_text  # noqa: E402
@@ -727,6 +728,85 @@ def _format_v2_source_line(payload: dict, date_s: str = "09.08.2026") -> str:
         {"get_weather": lambda *_args, **_kwargs: payload},
         lambda: format_v2_module._source_wind_pressure_line(date_s),
     )
+
+
+def cy_weather_attempts_request_only_sea_level_pressure() -> None:
+    assert len(weather_module.ATTEMPTS) == 5
+    for attempt in weather_module.ATTEMPTS:
+        assert "pressure_msl" in attempt.hourly
+        assert "surface_pressure" not in attempt.hourly
+        if attempt.current_mode == "current":
+            assert attempt.current_fields
+            assert "pressure_msl" in attempt.current_fields
+            assert "surface_pressure" not in attempt.current_fields
+
+
+def cy_post_common_prefers_sea_level_pressure_with_surface_fallback() -> None:
+    target = date(2026, 8, 9)
+    tz_obj = types.SimpleNamespace(name="Asia/Nicosia")
+
+    def metrics(payload: dict):
+        return _with_forecast_clock(
+            lambda: post_common_module._city_header_metrics_for_date(payload, tz_obj, target)
+        )
+
+    preferred = metrics(
+        {
+            "hourly": {
+                "time": ["2026-08-09T06:00", "2026-08-09T12:00"],
+                "pressure_msl": [1000.0, 1002.0],
+                "surface_pressure": [900.0, 899.0],
+            }
+        }
+    )
+    assert preferred[2:4] == (1002, "↑")
+
+    legacy = metrics(
+        {
+            "hourly": {
+                "time": ["2026-08-09T06:00", "2026-08-09T12:00"],
+                "surface_pressure": [1010.0, 1008.0],
+            }
+        }
+    )
+    assert legacy[2:4] == (1008, "↓")
+
+
+def cy_format_v2_prefers_sea_level_pressure_with_surface_fallback() -> None:
+    preferred = _format_v2_source_line(
+        {
+            "hourly": {
+                "time": ["2026-08-09T06:00", "2026-08-09T12:00"],
+                "pressure_msl": [1000.0, 1002.0],
+                "surface_pressure": [900.0, 899.0],
+            }
+        }
+    )
+    assert preferred == "🔹 1002 гПа ↑"
+
+    legacy = _format_v2_source_line(
+        {
+            "hourly": {
+                "time": ["2026-08-09T06:00", "2026-08-09T12:00"],
+                "surface_pressure": [1010.0, 1008.0],
+            }
+        }
+    )
+    assert legacy == "🔹 1008 гПа ↓"
+
+
+def cy_utils_pressure_trend_supports_sea_level_and_surface_pressure() -> None:
+    assert utils_module.pressure_trend(
+        {
+            "hourly": {
+                "pressure_msl": [1000.0, 1003.0],
+                "surface_pressure": [1000.0, 997.0],
+            }
+        }
+    ) == "↑"
+    assert utils_module.pressure_trend(
+        {"hourly": {"surface_pressure": [1000.0, 997.0]}}
+    ) == "↓"
 
 
 def cy_format_v2_source_uses_only_exact_target_date_hourly_values() -> None:
@@ -2629,6 +2709,10 @@ def cy_morning_safe_production_polish_keeps_fog_actions() -> None:
 
 def main() -> None:
     checks = (
+        cy_weather_attempts_request_only_sea_level_pressure,
+        cy_post_common_prefers_sea_level_pressure_with_surface_fallback,
+        cy_format_v2_prefers_sea_level_pressure_with_surface_fallback,
+        cy_utils_pressure_trend_supports_sea_level_and_surface_pressure,
         cy_morning_adds_concise_sea_block_when_available,
         cy_morning_source_rows_use_city_formatter_sst_and_preserve_evening,
         cy_morning_uses_today_for_raw_format_score_feels_and_plan,

--- a/utils.py
+++ b/utils.py
@@ -431,9 +431,15 @@ def kp_emoji(kp: Optional[float]) -> str:
 def pressure_trend(w: Dict[str, Any]) -> str:
     """
     ↑ если ближайший час > +2 гПа, ↓ если < −2, иначе →.
-    w — объект с hourly.surface_pressure (список чисел).
+    w — объект с hourly.pressure_msl или legacy hourly.surface_pressure/pressure.
     """
-    hp = w.get("hourly", {}).get("surface_pressure", [])
+    hourly = w.get("hourly", {})
+    hp = (
+        hourly.get("pressure_msl")
+        or hourly.get("surface_pressure")
+        or hourly.get("pressure")
+        or []
+    )
     if len(hp) < 2:
         return "→"
     diff = hp[1] - hp[0]

--- a/weather.py
+++ b/weather.py
@@ -93,7 +93,7 @@ HOURLY_FULL = [
     "wind_speed_10m",
     "wind_direction_10m",
     "wind_gusts_10m",
-    "surface_pressure",
+    "pressure_msl",
     "uv_index",
     "uv_index_clear_sky",
     "thunderstorm_probability",
@@ -131,7 +131,7 @@ HOURLY_MIN = [
     "wind_speed_10m",
     "wind_direction_10m",
     "wind_gusts_10m",
-    "surface_pressure",
+    "pressure_msl",
     "rain",
     "uv_index",
 ]
@@ -166,7 +166,7 @@ CURRENT_FULL = [
     "wind_speed_10m",
     "wind_direction_10m",
     "wind_gusts_10m",
-    "surface_pressure",
+    "pressure_msl",
 ]
 
 CURRENT_MIN = [
@@ -179,7 +179,7 @@ CURRENT_MIN = [
     "wind_speed_10m",
     "wind_direction_10m",
     "wind_gusts_10m",
-    "surface_pressure",
+    "pressure_msl",
 ]
 
 


### PR DESCRIPTION
## What changed

- Request Open-Meteo `pressure_msl` in every Cyprus weather attempt instead of `surface_pressure`.
- Prefer hourly `pressure_msl` in city rows, FORMAT_V2 source lines, and the exported pressure-trend helper.
- Preserve read compatibility in the order `pressure_msl → surface_pressure → pressure` for existing coordinate caches and legacy fixtures.
- Add four offline regressions covering request fields, consumer precedence, and legacy fallback behavior.

## Why

`surface_pressure` varies with terrain elevation, while mean sea-level pressure is the comparable island-wide value expected in Cyprus forecast posts. Existing cached payloads may still contain only `surface_pressure`, so the read fallback remains necessary.

## Scope

This PR changes only pressure-field selection and its offline regression coverage. It does not change weekly forecasting, post text, thresholds, units, cache keys or TTLs, SUP/Surf/Kite logic, workflows, or publication behavior.

## Validation

- 4/4 new pressure regressions passed separately.
- 276/276 offline checks passed across all 12 Cyprus PR suites.
- External socket connections were blocked during all regression runs.
- `python -m compileall` passed for the five changed files.
- `git diff --check` passed.
- Diff is limited to `weather.py`, `post_common.py`, `format_v2.py`, `utils.py`, and `tools/test_format_v2_morning_cy.py`.

No manual workflow, Telegram, weather/air/marine/Safecast/image-provider call, or publication was run.