### PR TITLE
F.2: build one canonical Cyprus visual decision per candidate

### DIFF
--- a/cyprus_image_recovery.py
+++ b/cyprus_image_recovery.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 import random
 import re
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont, PngImagePlugin
 
@@ -767,8 +767,19 @@ def _cover_aqi(final_text: str) -> tuple[str, str] | None:
     return str(value), label
 
 
-def _informative_cover_facts(final_text: str, *, post_type: str) -> tuple[object, dict[str, str]]:
-    ctx = parse_visual_context_cy(final_text, post_type=post_type)
+def _informative_cover_facts(
+    final_text: str,
+    *,
+    post_type: str,
+    visual_context: Any | None = None,
+) -> tuple[object, dict[str, str]]:
+    # A precomputed context comes from the canonical visual decision; reusing it keeps
+    # the fallback cover on the same provenance instead of parsing the post a second time.
+    ctx = (
+        visual_context
+        if visual_context is not None
+        else parse_visual_context_cy(final_text, post_type=post_type)
+    )
     headline = "КИПР СЕГОДНЯ" if post_type == "morning" else "КИПР ЗАВТРА"
     facts: list[str] = []
     hottest = ctx.hottest_city or ""
@@ -861,14 +872,25 @@ def render_local_informative_cover(
     post_type: str,
     output_path: str | Path,
     minimum_bytes: int,
+    visual_context: Any | None = None,
+    visibility_metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Render a deterministic factual Cyprus cover after network providers fail."""
+    """Render a deterministic factual Cyprus cover after network providers fail.
+
+    ``visual_context`` and ``visibility_metadata`` carry the canonical decision's
+    provenance. When supplied, the post is not parsed again; legacy callers that omit
+    them keep the previous parse-on-demand behaviour.
+    """
 
     safe_date = _safe_target_date(target_date)
     mode = str(post_type or "").strip().lower()
     if mode not in {"morning", "evening"}:
         raise ValueError(f"invalid Cyprus informative-cover post type: {post_type!r}")
-    ctx, facts = _informative_cover_facts(final_text, post_type=mode)
+    ctx, facts = _informative_cover_facts(
+        final_text,
+        post_type=mode,
+        visual_context=visual_context,
+    )
     palette, top, bottom, accent = _cover_palette(ctx)
     rendered_lines = [LOCAL_INFORMATIVE_COVER_BRANDING, facts["headline"]]
     rendered_lines.extend(value for key, value in facts.items() if key != "headline" and value)
@@ -954,6 +976,25 @@ def render_local_informative_cover(
         "palette": palette,
         "cache_key": cache_key,
     }
+    # Diagnostics-only provenance, appended AFTER the local cache key is final so the
+    # same factual inputs keep producing the same local cache key as before.
+    metadata["visibility_condition"] = str(getattr(ctx, "visibility_condition", ""))
+    metadata["visibility_forecast_window"] = str(
+        getattr(ctx, "visibility_forecast_window", "")
+    )
+    metadata["dust_vs_fog_classification"] = str(
+        getattr(ctx, "dust_vs_fog_classification", "")
+    )
+    metadata["visual_context_reused"] = str(visual_context is not None).lower()
+    metadata["visibility_metadata_provided"] = str(visibility_metadata is not None).lower()
+    if visibility_metadata is not None:
+        metadata["visibility_metadata"] = json.dumps(
+            dict(visibility_metadata),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
     png_info = PngImagePlugin.PngInfo()
     for key, value in metadata.items():
         png_info.add_text(key, str(value))

--- a/image_prompt_cy_scene.py
+++ b/image_prompt_cy_scene.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any, Mapping
 from urllib.parse import quote_plus
@@ -1280,7 +1281,62 @@ def build_cyprus_visual_cache_key(
     )["cache_key"]
 
 
-def build_cyprus_scene_prompt_with_metadata(
+@dataclass(frozen=True)
+class CyprusVisualDecision:
+    """One canonical Cyprus visual decision, reused across the whole candidate lifecycle.
+
+    The decision is built exactly once per visual candidate and then flows unchanged
+    through routing, prompt, provider, validation, dedup, diagnostics, history and
+    receipt, so every stage reports the same identity without re-parsing or reselecting.
+    """
+
+    context: VisualContextCY
+    prompt: str
+    style_name: str
+    metadata: dict[str, object]
+    visibility_metadata: Mapping[str, Any] | None = field(default=None)
+
+    @property
+    def decision_id(self) -> str:
+        return str(self.metadata.get("decision_id", ""))
+
+    @property
+    def cache_key(self) -> str:
+        return str(self.metadata.get("cache_key", ""))
+
+    @property
+    def selected_scene(self) -> str:
+        return str(self.metadata.get("selected_scene", ""))
+
+    @property
+    def composition(self) -> str:
+        return str(self.metadata.get("composition", ""))
+
+    @property
+    def visual_archetype(self) -> str:
+        return str(self.metadata.get("visual_archetype", ""))
+
+    @property
+    def forecast_date(self) -> str:
+        return str(self.metadata.get("forecast_date", ""))
+
+    @property
+    def post_type(self) -> str:
+        return str(self.metadata.get("post_type", ""))
+
+    def identity(self) -> dict[str, str]:
+        """Identity fields that must match across provider, dedup, history and receipt."""
+        return {
+            "decision_id": self.decision_id,
+            "selected_scene": self.selected_scene,
+            "composition": self.composition,
+            "visual_archetype": self.visual_archetype,
+            "style_name": self.style_name,
+            "cache_key": self.cache_key,
+        }
+
+
+def build_cyprus_visual_decision(
     final_format_v2_message: str,
     *,
     post_type: str = "evening",
@@ -1289,16 +1345,26 @@ def build_cyprus_scene_prompt_with_metadata(
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
     visibility_metadata: Mapping[str, Any] | None = None,
-) -> tuple[str, str, dict[str, object]]:
-    """Return a sanitized Cyprus prompt, stable style name, and visual cache metadata."""
+    visual_context: VisualContextCY | None = None,
+) -> CyprusVisualDecision:
+    """Build the canonical decision for one Cyprus visual candidate.
+
+    When ``visual_context`` is supplied it is used as-is: the parser is not run a
+    second time, so context provenance stays identical across the lifecycle. Callers
+    that do not have a precomputed context keep the previous parse-on-demand behaviour.
+    """
     mode = post_type.strip().lower()
     if mode not in {"morning", "evening"}:
         raise ValueError("post_type must be 'morning' or 'evening'")
 
-    ctx = build_visual_context_cy(
-        final_format_v2_message,
-        post_type=mode,
-        visibility_metadata=visibility_metadata,
+    ctx = (
+        visual_context
+        if visual_context is not None
+        else build_visual_context_cy(
+            final_format_v2_message,
+            post_type=mode,
+            visibility_metadata=visibility_metadata,
+        )
     )
     scene = apply_visual_rules_cy(ctx)
     moon_context = (
@@ -1347,7 +1413,64 @@ def build_cyprus_scene_prompt_with_metadata(
     metadata["positive_clause_count"] = len(final_positive)
     metadata["negative_item_count"] = len(final_negative)
     metadata["pollinations_encoded_url_length"] = encoded_url_length
-    return prompt, style_name, metadata
+
+    # Diagnostics-only provenance. Everything below is appended AFTER the ordered
+    # cache key, the prompt and the style digest are already final, so it can never
+    # change visual selection, the cache identity or the style name.
+    metadata["routing_inputs"] = {
+        "primary_weather": metadata["primary_weather"],
+        "hazards": metadata["hazards"],
+        "scene_focus": metadata["scene_focus"],
+        "visual_forecast_period": metadata["visual_forecast_period"],
+        "visibility_condition": metadata["visibility_condition"],
+        "weather_scenario": metadata["weather_scenario"],
+        "variation_attempt": metadata["variation_attempt"],
+    }
+    metadata["cooldown_inputs"] = {
+        "blocked_scenes": list(blocked_scenes),
+        "blocked_compositions": list(blocked_compositions),
+        "blocked_archetypes": list(blocked_archetypes),
+    }
+    metadata["decision_id"] = hashlib.sha256(
+        "|".join(
+            (
+                str(metadata["cache_key"]),
+                str(metadata["style_name"]),
+                prompt,
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+
+    return CyprusVisualDecision(
+        context=ctx,
+        prompt=prompt,
+        style_name=style_name,
+        metadata=metadata,
+        visibility_metadata=visibility_metadata,
+    )
+
+
+def build_cyprus_scene_prompt_with_metadata(
+    final_format_v2_message: str,
+    *,
+    post_type: str = "evening",
+    variation_attempt: int = 0,
+    blocked_scenes: tuple[str, ...] = (),
+    blocked_compositions: tuple[str, ...] = (),
+    blocked_archetypes: tuple[str, ...] = (),
+    visibility_metadata: Mapping[str, Any] | None = None,
+) -> tuple[str, str, dict[str, object]]:
+    """Return a sanitized Cyprus prompt, stable style name, and visual cache metadata."""
+    decision = build_cyprus_visual_decision(
+        final_format_v2_message,
+        post_type=post_type,
+        variation_attempt=variation_attempt,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        blocked_archetypes=blocked_archetypes,
+        visibility_metadata=visibility_metadata,
+    )
+    return decision.prompt, decision.style_name, decision.metadata
 
 
 def build_cyprus_scene_prompt(
@@ -1379,5 +1502,7 @@ __all__ = [
     "build_cyprus_visual_cache_key",
     "build_cyprus_scene_prompt",
     "build_cyprus_scene_prompt_with_metadata",
+    "build_cyprus_visual_decision",
+    "CyprusVisualDecision",
     "CYPRUS_VISUAL_PROMPT_VERSION",
 ]

--- a/post_cy.py
+++ b/post_cy.py
@@ -84,6 +84,32 @@ CODES = ("USD", "GBP", "TRY", "ILS")
 NBSP = "\u00A0"
 
 
+class legacy_cy_images_disabled:
+    """Disable the legacy ``post_common`` image pipeline for the duration of a call.
+
+    The legacy non-FORMAT_V2 path publishes Cyprus text through ``main_common()``,
+    whose ``CY_IMG_ENABLED`` default is ``1``. Canonical Cyprus visuals are produced
+    only by the FORMAT_V2 path, so the legacy pipeline must not emit a production
+    image. The previous value is always restored, including on exceptions.
+    """
+
+    _ENV_NAME = "CY_IMG_ENABLED"
+
+    def __init__(self) -> None:
+        self._old_value: Optional[str] = None
+
+    def __enter__(self) -> "legacy_cy_images_disabled":
+        self._old_value = os.environ.get(self._ENV_NAME)
+        os.environ[self._ENV_NAME] = "0"
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._old_value is None:
+            os.environ.pop(self._ENV_NAME, None)
+        else:
+            os.environ[self._ENV_NAME] = self._old_value
+
+
 def _env_true(name: str) -> bool:
     return str(os.getenv(name, "")).strip().lower() in ("1", "true", "yes", "on")
 
@@ -616,7 +642,8 @@ async def main_cy() -> None:
         except Exception:
             pass
 
-        await main_common(**kwargs)  # type: ignore[misc]
+        with legacy_cy_images_disabled():
+            await main_common(**kwargs)  # type: ignore[misc]
 
 
 if __name__ == "__main__":

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import datetime as dt
+import hashlib
 import json
 import logging
 import os
@@ -1696,6 +1697,24 @@ _CY_FALLBACK_LOCAL_SELECTED = "local_selected"
 _CY_FALLBACK_LOCAL_FAILED = "local_failed"
 
 
+def _cy_local_decision_id(local_metadata: dict) -> str:
+    """Deterministic diagnostics-only id for a local informative-cover decision.
+
+    Derived from the local identity that is already final, so it never enters the
+    local cache payload and cannot change the renderer's existing cache key.
+    """
+    parts = (
+        str(local_metadata.get("cache_key", "")),
+        _CY_LOCAL_RENDERER_NAME,
+        str(local_metadata.get("selected_scene", "")),
+        str(local_metadata.get("composition", "")),
+        str(local_metadata.get("visual_archetype", "")),
+        str(local_metadata.get("target_date", "")),
+        str(local_metadata.get("post_type", "")),
+    )
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:16]
+
+
 def _cy_fallback_state(
     result: str,
     *,
@@ -1940,6 +1959,9 @@ async def _build_safe_test_image(
 
     last_metadata: dict | None = None
     last_decision: object | None = None
+    # Tracks which lifecycle stage is currently executing, so an escaping exception is
+    # attributed to the stage that actually raised it instead of a blanket fallback.
+    lifecycle_stage = "orchestration"
     attempts: list[dict] = []
     telegram_attempts: list[dict] = []
     target_date_for_diag = "undated"
@@ -1983,11 +2005,13 @@ async def _build_safe_test_image(
         # Parse the finalized post exactly once. Every candidate decision, the local
         # fallback renderer and all diagnostics reuse this context, so the whole
         # lifecycle reports one consistent provenance.
+        lifecycle_stage = "decision"
         canonical_visual_context = build_visual_context_cy(
             final_text,
             post_type=mode,
             visibility_metadata=visibility_metadata,
         )
+        lifecycle_stage = "orchestration"
 
         history_namespace = "test" if send_image_to_test else "prod" if send_image_to_chat else "test"
         write_history_path = cyprus_visual_history_path(history_namespace)
@@ -2059,6 +2083,7 @@ async def _build_safe_test_image(
         unconfigured_backends: list[str] = []
         local_fallback_generated = False
         local_render_failed = False
+        last_failure_stage = ""
         horde_credential_state: dict[str, object] = {}
 
         def _remaining_provider_calls() -> dict[str, int]:
@@ -2102,6 +2127,7 @@ async def _build_safe_test_image(
             and backend_generation_calls < backend_call_limit
             and variation_attempt < 40
         ):
+            lifecycle_stage = "decision"
             decision = visual_decision_module.build_cyprus_visual_decision(
                 final_text,
                 post_type=mode,
@@ -2112,6 +2138,7 @@ async def _build_safe_test_image(
                 visibility_metadata=visibility_metadata,
                 visual_context=canonical_visual_context,
             )
+            lifecycle_stage = "orchestration"
             prompt = decision.prompt
             style_name = decision.style_name
             metadata = decision.metadata
@@ -2219,6 +2246,7 @@ async def _build_safe_test_image(
             outcome_exhausted = False
             structured_outcome_returned = False
             stop_generation = False
+            lifecycle_stage = "provider_generation"
             try:
                 if cache_state == "hit":
                     generated = str(requested_path)
@@ -2301,6 +2329,7 @@ async def _build_safe_test_image(
                     backend = _cy_image_backend_name(generated)
                     image_path = _cy_image_result_path(generated)
 
+                lifecycle_stage = "provider_validation"
                 if image_path is None or not image_path.is_file():
                     raise RuntimeError(f"generated image does not exist: {image_path}")
 
@@ -2311,6 +2340,9 @@ async def _build_safe_test_image(
                         f"must be greater than {minimum}"
                     )
             except Exception as exc:
+                # Remember whether the provider itself or its output validation failed.
+                last_failure_stage = lifecycle_stage
+                lifecycle_stage = "orchestration"
                 generation_failures += 1
                 if (
                     cache_state != "hit"
@@ -2367,6 +2399,7 @@ async def _build_safe_test_image(
                 continue
 
             valid_candidate_count += 1
+            lifecycle_stage = "dedup"
             duplicate_result = evaluate_cyprus_visual_candidate(
                 image_path,
                 date_value=metadata["forecast_date"],
@@ -2377,6 +2410,7 @@ async def _build_safe_test_image(
                 visual_archetype=metadata.get("visual_archetype"),
                 reference_history_paths=reference_history_paths,
             )
+            lifecycle_stage = "orchestration"
             print(
                 "CY_SAFE_IMAGE_DEDUP: "
                 f"{duplicate_result.reason}; sha256={duplicate_result.sha256[:12]}; "
@@ -2544,6 +2578,7 @@ async def _build_safe_test_image(
                 local_path = _cy_safe_image_output_path(
                     f"local_informative_cover_{target_date_for_diag}_{mode}"
                 ).with_suffix(".png")
+                lifecycle_stage = "fallback_render"
                 try:
                     local_result = render_local_informative_cover(
                         final_text,
@@ -2579,12 +2614,21 @@ async def _build_safe_test_image(
                     )
                     last_metadata = local_metadata
                     local_render_failed = True
+                    last_failure_stage = "fallback_render"
+                    lifecycle_stage = "orchestration"
                     logging.error("Cyprus local informative cover failed non-fatally: %s", exc)
                 else:
+                    lifecycle_stage = "orchestration"
                     local_path = Path(str(local_result["path"]))
                     local_size = int(local_result["bytes"])
                     renderer_metadata = dict(local_result.get("metadata") or {})
                     local_metadata.update(renderer_metadata)
+                    # The local cover carries its own identity: the network style name and
+                    # network decision_id inherited from last_metadata must not survive.
+                    # The renderer's cache key is already final at this point, so the local
+                    # decision_id below is diagnostics-only and cannot affect it.
+                    local_metadata["style_name"] = _CY_LOCAL_RENDERER_NAME
+                    local_metadata["decision_id"] = _cy_local_decision_id(local_metadata)
                     local_sha256 = sha256_file(local_path)
                     existing_local_exact = next(
                         (
@@ -2711,7 +2755,12 @@ async def _build_safe_test_image(
                     reference_history_paths=reference_history_paths,
                     history_count_before=before_history_count,
                     generation_summary=_generation_summary(final_reason),
-                    error_stage="provider_generation",
+                    # A failed local cover is a fallback_render failure, not a provider one.
+                    error_stage=(
+                        "fallback_render"
+                        if local_render_failed
+                        else (last_failure_stage or "provider_generation")
+                    ),
                 )
                 logging.error("CY SAFE IMAGE failed after candidate errors: %s", error)
                 return {
@@ -2826,6 +2875,7 @@ async def _build_safe_test_image(
                 metadata["forecast_date"],
                 test_label=image_caption_is_test,
             )
+            lifecycle_stage = "telegram_send"
             sent_message, telegram_attempts = await _cy_send_photo_with_retry(
                 image_bot,
                 chat_id=image_chat,
@@ -2835,6 +2885,7 @@ async def _build_safe_test_image(
             message_id = getattr(sent_message, "message_id", None)
             if isinstance(message_id, int):
                 sent_message_ids.append(message_id)
+            lifecycle_stage = "history"
             history_entry = record_cyprus_visual_publication(
                 date_value=metadata["forecast_date"],
                 post_type=mode,
@@ -2848,6 +2899,7 @@ async def _build_safe_test_image(
                 history_path=write_history_path,
             )
             after_history_count = len(load_cyprus_visual_history(write_history_path))
+            lifecycle_stage = "orchestration"
             print(f"CY_SAFE_IMAGE_HISTORY_COUNT_AFTER: {after_history_count}")
             logging.info(
                 "Cyprus visual history count after publication: namespace=%s path=%s count=%s",
@@ -2875,8 +2927,10 @@ async def _build_safe_test_image(
                     "run_attempt": os.getenv("GITHUB_RUN_ATTEMPT", ""),
                     "sent_at_utc": _cy_utc_now(),
                 }
+                lifecycle_stage = "receipt"
                 receipt_path = _cy_image_receipt_path(metadata["forecast_date"], mode)
                 _cy_write_json_atomic(receipt_path, receipt)
+                lifecycle_stage = "orchestration"
                 print(f"CY_SAFE_IMAGE_RECEIPT_WRITTEN: {receipt_path}")
             elif production_image_send:
                 print("CY_SAFE_IMAGE_RECEIPT_NOT_WRITTEN: missing valid Telegram message_id")
@@ -2943,7 +2997,8 @@ async def _build_safe_test_image(
             reference_history_paths=reference_history_paths_for_diag,
             history_count_before=before_history_count,
             history_count_after=after_history_count,
-            error_stage="orchestration",
+            # Attribute the failure to the stage that was actually executing.
+            error_stage=lifecycle_stage,
         )
         logging.exception(
             "CY SAFE IMAGE failed; existing text safe-test flow will continue: %s",

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -1673,6 +1673,62 @@ def _cy_is_production_text_send(chat_id: int | None) -> bool:
     return bool(production_chat and chat_id is not None and str(chat_id) == production_chat)
 
 
+_CY_LOCAL_RENDERER_NAME = "local_informative_cover"
+
+# Fixed vocabulary; diagnostics must not invent new stage names.
+_CY_ERROR_STAGES = (
+    "none",
+    "decision",
+    "provider_generation",
+    "provider_validation",
+    "dedup",
+    "fallback_render",
+    "telegram_send",
+    "history",
+    "receipt",
+    "orchestration",
+)
+
+# Unambiguous lifecycle states for the network → local fallback transition.
+_CY_FALLBACK_NOT_USED = "network_fallback_not_used"
+_CY_FALLBACK_ELIGIBLE = "network_exhausted_local_eligible"
+_CY_FALLBACK_LOCAL_SELECTED = "local_selected"
+_CY_FALLBACK_LOCAL_FAILED = "local_failed"
+
+
+def _cy_fallback_state(
+    result: str,
+    *,
+    local_generated: bool,
+    local_failed: bool = False,
+    is_local: bool = False,
+) -> str:
+    """Derive the fallback lifecycle state from the outcome actually reached."""
+    if is_local or local_generated:
+        return _CY_FALLBACK_LOCAL_SELECTED
+    if local_failed:
+        return _CY_FALLBACK_LOCAL_FAILED
+    if str(result) in {"failed", "failed_non_fatal", "failed_after_duplicates"}:
+        return _CY_FALLBACK_ELIGIBLE
+    return _CY_FALLBACK_NOT_USED
+
+
+def _cy_normalize_error_stage(
+    error_stage: str,
+    result: str,
+    error: BaseException | None,
+) -> str:
+    """Clamp the reported stage to the fixed vocabulary."""
+    stage = str(error_stage or "").strip()
+    if stage in _CY_ERROR_STAGES:
+        return stage
+    if error is None and str(result) in {"sent", "generated"}:
+        return "none"
+    if error is None:
+        return "none"
+    return "orchestration"
+
+
 def _cy_write_image_diagnostics(
     *,
     mode: str,
@@ -1687,6 +1743,8 @@ def _cy_write_image_diagnostics(
     history_count_before: int | None = None,
     history_count_after: int | None = None,
     generation_summary: dict | None = None,
+    fallback_state: str = "",
+    error_stage: str = "",
 ) -> Path:
     safe_date = re.sub(r"[^0-9-]+", "_", target_date or "undated")
     out_dir = Path(os.getenv("CY_IMAGE_DIAGNOSTICS_DIR", str(_CY_IMAGE_DIAGNOSTICS_DIR))) / f"{safe_date}-{mode}"
@@ -1704,6 +1762,25 @@ def _cy_write_image_diagnostics(
         "history_count_after": history_count_after,
     }
     payload.update(generation_summary or {})
+    # Canonical decision identity and the actual lifecycle outcome, surfaced as
+    # unambiguous top-level fields rather than a separate diagnostics architecture.
+    meta = prompt_metadata or {}
+    summary = generation_summary or {}
+    backend = str(summary.get("selected_backend") or "")
+    is_local = backend == _CY_LOCAL_RENDERER_NAME
+    payload["decision_id"] = meta.get("decision_id", "")
+    payload["routing_inputs"] = meta.get("routing_inputs", {})
+    payload["cooldown_inputs"] = meta.get("cooldown_inputs", {})
+    # A local cover is never reported as if a network provider had produced it.
+    payload["actual_provider"] = "" if is_local else backend
+    payload["actual_renderer"] = _CY_LOCAL_RENDERER_NAME if is_local else ""
+    payload["fallback_state"] = fallback_state or _cy_fallback_state(
+        result,
+        local_generated=bool(summary.get("local_fallback_generated")),
+        local_failed=bool(summary.get("local_render_failed")),
+        is_local=is_local,
+    )
+    payload["error_stage"] = _cy_normalize_error_stage(error_stage, result, error)
     if error is not None:
         payload["error"] = {
             "type": type(error).__name__,
@@ -1862,6 +1939,7 @@ async def _build_safe_test_image(
             )
 
     last_metadata: dict | None = None
+    last_decision: object | None = None
     attempts: list[dict] = []
     telegram_attempts: list[dict] = []
     target_date_for_diag = "undated"
@@ -1890,7 +1968,8 @@ async def _build_safe_test_image(
             render_local_informative_cover,
             write_provider_health,
         )
-        from image_prompt_cy_scene import build_cyprus_scene_prompt_with_metadata
+        import image_prompt_cy_scene as visual_decision_module
+        from image_prompt_cy_scene import build_visual_context_cy
         from weather import load_cyprus_visibility_diagnostics
         import world_en.imagegen as imagegen_module
 
@@ -1900,6 +1979,15 @@ async def _build_safe_test_image(
                 visibility_target_date,
                 mode,
             )
+
+        # Parse the finalized post exactly once. Every candidate decision, the local
+        # fallback renderer and all diagnostics reuse this context, so the whole
+        # lifecycle reports one consistent provenance.
+        canonical_visual_context = build_visual_context_cy(
+            final_text,
+            post_type=mode,
+            visibility_metadata=visibility_metadata,
+        )
 
         history_namespace = "test" if send_image_to_test else "prod" if send_image_to_chat else "test"
         write_history_path = cyprus_visual_history_path(history_namespace)
@@ -1970,6 +2058,7 @@ async def _build_safe_test_image(
         available_backends: list[str] = []
         unconfigured_backends: list[str] = []
         local_fallback_generated = False
+        local_render_failed = False
         horde_credential_state: dict[str, object] = {}
 
         def _remaining_provider_calls() -> dict[str, int]:
@@ -2003,6 +2092,7 @@ async def _build_safe_test_image(
                 "provider_call_counts": provider_call_counts,
                 "provider_health_path": provider_health_file,
                 "local_fallback_generated": local_fallback_generated,
+                "local_render_failed": local_render_failed,
                 "selected_backend": selected_backend,
                 "final_reason": final_reason,
             }
@@ -2012,7 +2102,7 @@ async def _build_safe_test_image(
             and backend_generation_calls < backend_call_limit
             and variation_attempt < 40
         ):
-            prompt, style_name, metadata = build_cyprus_scene_prompt_with_metadata(
+            decision = visual_decision_module.build_cyprus_visual_decision(
                 final_text,
                 post_type=mode,
                 variation_attempt=variation_attempt,
@@ -2020,8 +2110,13 @@ async def _build_safe_test_image(
                 blocked_compositions=recent_composition_values,
                 blocked_archetypes=blocked_archetypes,
                 visibility_metadata=visibility_metadata,
+                visual_context=canonical_visual_context,
             )
+            prompt = decision.prompt
+            style_name = decision.style_name
+            metadata = decision.metadata
             last_metadata = dict(metadata)
+            last_decision = decision
             target_date_for_diag = str(metadata["forecast_date"])
             cache_key = metadata["cache_key"]
             if provider_health is None:
@@ -2378,9 +2473,7 @@ async def _build_safe_test_image(
             )
 
             candidate = (
-                prompt,
-                style_name,
-                metadata,
+                decision,
                 image_path,
                 image_size,
                 duplicate_result,
@@ -2458,6 +2551,8 @@ async def _build_safe_test_image(
                         post_type=mode,
                         output_path=local_path,
                         minimum_bytes=minimum,
+                        visual_context=canonical_visual_context,
+                        visibility_metadata=visibility_metadata,
                     )
                 except Exception as exc:
                     attempts.append(
@@ -2483,6 +2578,7 @@ async def _build_safe_test_image(
                         }
                     )
                     last_metadata = local_metadata
+                    local_render_failed = True
                     logging.error("Cyprus local informative cover failed non-fatally: %s", exc)
                 else:
                     local_path = Path(str(local_result["path"]))
@@ -2551,9 +2647,13 @@ async def _build_safe_test_image(
                             **_generation_summary(final_reason, "local_informative_cover"),
                         }
                     selected_candidate = (
-                        "",
-                        "local_informative_cover",
-                        local_metadata,
+                        visual_decision_module.CyprusVisualDecision(
+                            context=canonical_visual_context,
+                            prompt="",
+                            style_name="local_informative_cover",
+                            metadata=local_metadata,
+                            visibility_metadata=visibility_metadata,
+                        ),
                         local_path,
                         local_size,
                         None,
@@ -2585,6 +2685,7 @@ async def _build_safe_test_image(
                     reference_history_paths=reference_history_paths,
                     history_count_before=before_history_count,
                     generation_summary=_generation_summary(final_reason),
+                    error_stage="dedup",
                 )
                 logging.error("CY SAFE IMAGE failed after duplicates and backend errors: %s", error)
                 return {
@@ -2610,6 +2711,7 @@ async def _build_safe_test_image(
                     reference_history_paths=reference_history_paths,
                     history_count_before=before_history_count,
                     generation_summary=_generation_summary(final_reason),
+                    error_stage="provider_generation",
                 )
                 logging.error("CY SAFE IMAGE failed after candidate errors: %s", error)
                 return {
@@ -2641,7 +2743,13 @@ async def _build_safe_test_image(
                 **_generation_summary(final_reason),
             }
 
-        prompt, style_name, metadata, image_path, image_size, duplicate_result, selected_backend = selected_candidate
+        # The canonical decision selected above is reused verbatim: no late rebuild and
+        # no reselection, so provider input, dedup, history, receipt and diagnostics all
+        # report the same identity.
+        selected_decision, image_path, image_size, duplicate_result, selected_backend = selected_candidate
+        prompt = selected_decision.prompt
+        style_name = selected_decision.style_name
+        metadata = selected_decision.metadata
 
         print(f"CY_SAFE_IMAGE_PATH: {image_path.resolve()}")
         print(f"CY_SAFE_IMAGE_BYTES: {image_size}")
@@ -2835,6 +2943,7 @@ async def _build_safe_test_image(
             reference_history_paths=reference_history_paths_for_diag,
             history_count_before=before_history_count,
             history_count_after=after_history_count,
+            error_stage="orchestration",
         )
         logging.exception(
             "CY SAFE IMAGE failed; existing text safe-test flow will continue: %s",

--- a/tools/test_cyprus_image_fallback.py
+++ b/tools/test_cyprus_image_fallback.py
@@ -727,6 +727,45 @@ def primary_evening_incident_sends_local_visual_before_text() -> None:
             assert local_history[0]["cache_key"] == receipt["cache_key"]
             assert diagnostics["prompt_metadata"]["cache_key"] == receipt["cache_key"]
 
+            # F.2 follow-up: the local cover owns its identity. The network style name
+            # and network decision_id must not survive into the local decision.
+            local_metadata = diagnostics["prompt_metadata"]
+            assert local_metadata["style_name"] == "local_informative_cover"
+            assert receipt["style_name"] == local_metadata["style_name"]
+            if "style_name" in local_history[0]:
+                assert local_history[0]["style_name"] == receipt["style_name"]
+
+            local_decision_id = local_metadata["decision_id"]
+            assert local_decision_id
+            assert diagnostics["decision_id"] == local_decision_id
+
+            # No network decision_id may leak into the local diagnostics. Rebuild the
+            # network decisions this run actually produced and prove none of them match.
+            import image_prompt_cy_scene as scene_module
+
+            network_decision_ids = {
+                scene_module.build_cyprus_visual_decision(
+                    EVENING_MESSAGE,
+                    post_type="evening",
+                    variation_attempt=attempt,
+                ).decision_id
+                for attempt in range(4)
+            }
+            assert local_decision_id not in network_decision_ids
+            assert local_metadata["cache_key"].startswith(LOCAL_INFORMATIVE_COVER_VERSION)
+
+            # The local renderer's own cache key must stay byte-for-byte unchanged.
+            with tempfile.TemporaryDirectory() as probe_dir:
+                probe = cyprus_image_recovery.render_local_informative_cover(
+                    EVENING_MESSAGE,
+                    target_date="2026-07-16",
+                    post_type="evening",
+                    output_path=Path(probe_dir) / "probe.png",
+                    minimum_bytes=12000,
+                )
+            assert probe["metadata"]["cache_key"] == local_metadata["cache_key"]
+            assert probe["metadata"]["renderer_version"] == LOCAL_INFORMATIVE_COVER_VERSION
+
             amain_source = inspect.getsource(safe_module.main)
             image_index = amain_source.index("image_result = await _build_safe_test_image(")
             recovery_return_index = amain_source.index("if args.image_only_recovery:", image_index)
@@ -1343,6 +1382,189 @@ def canonical_decision_is_not_rebuilt_after_provider_success() -> None:
         asyncio.run(run_case(Path(tmp_name)))
 
 
+def _run_stage_failure_case(
+    tmp: Path,
+    *,
+    break_telegram: bool = False,
+    break_history: bool = False,
+    break_receipt: bool = False,
+    break_local_renderer: bool = False,
+) -> dict:
+    """Drive _build_safe_test_image with one lifecycle stage failing; return diagnostics.
+
+    Everything is stubbed: no Telegram, no provider and no network access.
+    """
+    import image_prompt_cy_scene  # noqa: F401  (kept local, mirrors production import)
+
+    old_env = {name: os.environ.get(name) for name in (
+        "CHANNEL_ID",
+        "CY_SAFE_IMAGE_DIR",
+        "CY_IMG_MIN_BYTES",
+        "CY_IMAGE_DELIVERY_DIR",
+        "CY_TEXT_DELIVERY_DIR",
+        "CY_IMAGE_DIAGNOSTICS_DIR",
+        "CY_IMAGE_PROVIDER_HEALTH_DIR",
+    )}
+    old_token = safe_module.TOKEN
+    old_bot = safe_module.Bot
+    old_outcome = imagegen.generate_astro_image_outcome_with_exclusions
+    old_availability = imagegen.configured_image_backends
+    old_record = cyprus_visual_dedup.record_cyprus_visual_publication
+    old_renderer = cyprus_image_recovery.render_local_informative_cover
+    old_atomic = safe_module._cy_write_json_atomic
+    old_prod_history = cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH
+    old_test_history = cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH
+
+    history_path = tmp / "cyprus_visual_history_prod.json"
+    history_path.write_text("[]", "utf-8")
+    test_history_path = tmp / "cyprus_visual_history_test.json"
+    test_history_path.write_text("[]", "utf-8")
+
+    def fake_outcome(_prompt: str, requested_path: str, **_kwargs):
+        if break_local_renderer:
+            # Force the network path to fail so the local fallback is reached.
+            return types.SimpleNamespace(
+                result=None,
+                backend_attempts=[{"backend": "pollinations", "result": "failed"}],
+                error_type="BackendFailed",
+                error_message="fixture provider failure",
+                exhausted=True,
+                actual_backend_call_count=1,
+            )
+        path = Path(requested_path).with_suffix(".ppm")
+        _write_dhash_fixture(path, flipped_rows=11)
+        attempts = [{"backend": "pollinations", "result": "success", "http_status": 200}]
+        return types.SimpleNamespace(
+            result=types.SimpleNamespace(
+                path=str(path),
+                backend="pollinations",
+                byte_count=path.stat().st_size,
+                backend_attempts=attempts,
+            ),
+            backend_attempts=attempts,
+            error_type="",
+            error_message="",
+            exhausted=False,
+            actual_backend_call_count=1,
+        )
+
+    class FakeBot:
+        def __init__(self, token: str) -> None:
+            self.token = token
+
+        async def send_photo(self, **kwargs):
+            kwargs["photo"].read()
+            if break_telegram:
+                raise RuntimeError("fixture telegram send failure")
+            return types.SimpleNamespace(message_id=4242)
+
+    def failing_record(**_kwargs):
+        raise RuntimeError("fixture history write failure")
+
+    def failing_renderer(*_args, **_kwargs):
+        raise RuntimeError("fixture local renderer failure")
+
+    def guarded_atomic(path, payload):
+        if break_receipt and "cy_image_delivery" in str(path):
+            raise RuntimeError("fixture receipt write failure")
+        return old_atomic(path, payload)
+
+    try:
+        os.environ.update(
+            {
+                "CHANNEL_ID": "777",
+                "CY_SAFE_IMAGE_DIR": str(tmp / "images"),
+                "CY_IMG_MIN_BYTES": "10",
+                "CY_IMAGE_DELIVERY_DIR": str(tmp / "cy_image_delivery"),
+                "CY_TEXT_DELIVERY_DIR": str(tmp / "cy_text_delivery"),
+                "CY_IMAGE_DIAGNOSTICS_DIR": str(tmp / "cy_image_diagnostics"),
+                "CY_IMAGE_PROVIDER_HEALTH_DIR": str(tmp / "cy_image_provider_health"),
+            }
+        )
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH = history_path
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH = test_history_path
+        safe_module.TOKEN = "fixture-token"
+        safe_module.Bot = FakeBot
+        imagegen.generate_astro_image_outcome_with_exclusions = fake_outcome
+        imagegen.configured_image_backends = lambda **_kwargs: {
+            "configured_backends": ["pollinations"],
+            "available_backends": ["pollinations"],
+            "unconfigured_backends": [],
+        }
+        if break_history:
+            cyprus_visual_dedup.record_cyprus_visual_publication = failing_record
+            safe_module.record_cyprus_visual_publication = failing_record
+        if break_local_renderer:
+            cyprus_image_recovery.render_local_informative_cover = failing_renderer
+        if break_receipt:
+            safe_module._cy_write_json_atomic = guarded_atomic
+
+        result = asyncio.run(
+            safe_module._build_safe_test_image(
+                EVENING_MESSAGE,
+                "evening",
+                generate_image=True,
+                send_image_to_test=False,
+                send_image_to_chat=True,
+                image_chat_id=777,
+                image_only_recovery=False,
+            )
+        )
+        diagnostics = json.loads(
+            (tmp / "cy_image_diagnostics" / "2026-07-16-evening" / "image_result.json").read_text("utf-8")
+        )
+    finally:
+        cyprus_visual_dedup.record_cyprus_visual_publication = old_record
+        safe_module.record_cyprus_visual_publication = old_record
+        cyprus_image_recovery.render_local_informative_cover = old_renderer
+        safe_module._cy_write_json_atomic = old_atomic
+        imagegen.generate_astro_image_outcome_with_exclusions = old_outcome
+        imagegen.configured_image_backends = old_availability
+        safe_module.TOKEN = old_token
+        safe_module.Bot = old_bot
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH = old_prod_history
+        cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH = old_test_history
+        for name, value in old_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    return {"result": result, "diagnostics": diagnostics}
+
+
+def error_stage_reports_the_failing_lifecycle_stage() -> None:
+    """Real Telegram/history/receipt/renderer failures must not all read 'orchestration'."""
+    vocabulary = set(safe_module._CY_ERROR_STAGES)
+
+    cases = (
+        ("telegram_send", {"break_telegram": True}),
+        ("history", {"break_history": True}),
+        ("receipt", {"break_receipt": True}),
+        ("fallback_render", {"break_local_renderer": True}),
+    )
+    for expected_stage, kwargs in cases:
+        with tempfile.TemporaryDirectory() as tmp_name:
+            outcome = _run_stage_failure_case(Path(tmp_name), **kwargs)
+        diagnostics = outcome["diagnostics"]
+        stage = diagnostics["error_stage"]
+        assert stage in vocabulary, (expected_stage, stage)
+        assert stage == expected_stage, (
+            f"expected error_stage={expected_stage!r}, got {stage!r} "
+            f"(image_result={diagnostics['image_result']!r})"
+        )
+        assert stage != "orchestration", expected_stage
+
+
+def error_stage_is_none_on_successful_send() -> None:
+    with tempfile.TemporaryDirectory() as tmp_name:
+        outcome = _run_stage_failure_case(Path(tmp_name))
+    assert outcome["result"]["result"] == "sent"
+    assert outcome["diagnostics"]["error_stage"] == "none"
+    assert outcome["diagnostics"]["actual_provider"] == "pollinations"
+    assert outcome["diagnostics"]["actual_renderer"] == ""
+
+
 def main() -> None:
     checks = (
         local_informative_cover_is_valid_deterministic_and_factual,
@@ -1354,6 +1576,8 @@ def main() -> None:
         informative_cover_failure_falls_through_to_text_without_stale_image,
         local_cover_reuses_precomputed_context_without_reparse,
         canonical_decision_is_not_rebuilt_after_provider_success,
+        error_stage_reports_the_failing_lifecycle_stage,
+        error_stage_is_none_on_successful_send,
     )
     for check in checks:
         check()

--- a/tools/test_cyprus_image_fallback.py
+++ b/tools/test_cyprus_image_fallback.py
@@ -707,6 +707,26 @@ def primary_evening_incident_sends_local_visual_before_text() -> None:
             assert local_attempt["local_metadata"]["renderer_version"] == LOCAL_INFORMATIVE_COVER_VERSION
             assert local_attempt["local_metadata"]["rendered_text"]
 
+            # F.2: the local cover must not be reported as a network provider, and the
+            # lifecycle state must say plainly that the local fallback was selected.
+            assert diagnostics["actual_renderer"] == "local_informative_cover"
+            assert diagnostics["actual_provider"] == ""
+            assert diagnostics["fallback_state"] == "local_selected"
+            assert diagnostics["error_stage"] == "none"
+
+            # F.2: receipt, history and diagnostics must share one canonical identity.
+            history_entries = json.loads(history_path.read_text("utf-8"))
+            local_history = [
+                entry
+                for entry in history_entries
+                if str(entry.get("selected_scene")) == "local_informative_cover"
+            ]
+            assert len(local_history) == 1
+            for field in ("selected_scene", "composition", "visual_archetype"):
+                assert local_history[0][field] == receipt[field], field
+            assert local_history[0]["cache_key"] == receipt["cache_key"]
+            assert diagnostics["prompt_metadata"]["cache_key"] == receipt["cache_key"]
+
             amain_source = inspect.getsource(safe_module.main)
             image_index = amain_source.index("image_result = await _build_safe_test_image(")
             recovery_return_index = amain_source.index("if args.image_only_recovery:", image_index)
@@ -1081,6 +1101,248 @@ def informative_cover_failure_falls_through_to_text_without_stale_image() -> Non
         asyncio.run(run_case(Path(tmp_name)))
 
 
+def local_cover_reuses_precomputed_context_without_reparse() -> None:
+    """The canonical context must reach the renderer, which must not parse again."""
+    from visual_context_cy import parse_visual_context_cy as real_parse
+
+    precomputed = real_parse(EVENING_MESSAGE, post_type="evening")
+    visibility_metadata = {
+        "visibility_condition": "clear",
+        "source": "fixture-provenance",
+    }
+
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("local cover parsed the visual context a second time")
+
+    old_parse = cyprus_image_recovery.parse_visual_context_cy
+    cyprus_image_recovery.parse_visual_context_cy = _explode
+    try:
+        with tempfile.TemporaryDirectory() as tmp_name:
+            tmp = Path(tmp_name)
+            reused = render_local_informative_cover(
+                EVENING_MESSAGE,
+                target_date="2026-07-16",
+                post_type="evening",
+                output_path=tmp / "reused.png",
+                minimum_bytes=12000,
+                visual_context=precomputed,
+                visibility_metadata=visibility_metadata,
+            )
+    finally:
+        cyprus_image_recovery.parse_visual_context_cy = old_parse
+
+    metadata = reused["metadata"]
+    assert metadata["visual_context_reused"] == "true"
+    assert metadata["visibility_metadata_provided"] == "true"
+    assert json.loads(metadata["visibility_metadata"]) == visibility_metadata
+    assert metadata["visibility_condition"] == str(precomputed.visibility_condition)
+
+    # The same factual inputs must keep the previous local cache key: provenance is
+    # diagnostics-only and is appended after the cache key is computed.
+    with tempfile.TemporaryDirectory() as tmp_name:
+        legacy = render_local_informative_cover(
+            EVENING_MESSAGE,
+            target_date="2026-07-16",
+            post_type="evening",
+            output_path=Path(tmp_name) / "legacy.png",
+            minimum_bytes=12000,
+        )
+    assert legacy["metadata"]["cache_key"] == metadata["cache_key"]
+    assert legacy["metadata"]["renderer_version"] == LOCAL_INFORMATIVE_COVER_VERSION
+    assert legacy["metadata"]["visual_context_reused"] == "false"
+
+
+def canonical_decision_is_not_rebuilt_after_provider_success() -> None:
+    """One decision per candidate: provider, dedup, history and receipt share it."""
+    import image_prompt_cy_scene
+
+    async def run_case(tmp: Path) -> None:
+        old_env = {name: os.environ.get(name) for name in (
+            "CHANNEL_ID",
+            "CY_SAFE_IMAGE_DIR",
+            "CY_IMG_MIN_BYTES",
+            "CY_IMAGE_DELIVERY_DIR",
+            "CY_TEXT_DELIVERY_DIR",
+            "CY_IMAGE_DIAGNOSTICS_DIR",
+            "CY_IMAGE_PROVIDER_HEALTH_DIR",
+        )}
+        old_token = safe_module.TOKEN
+        old_bot = safe_module.Bot
+        old_outcome = imagegen.generate_astro_image_outcome_with_exclusions
+        old_availability = imagegen.configured_image_backends
+        old_builder = image_prompt_cy_scene.build_cyprus_visual_decision
+        old_prod_history = cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH
+        old_test_history = cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH
+
+        history_path = tmp / "cyprus_visual_history_prod.json"
+        history_path.write_text("[]", "utf-8")
+        test_history_path = tmp / "cyprus_visual_history_test.json"
+        test_history_path.write_text("[]", "utf-8")
+
+        builder_calls: list[dict] = []
+        provider_prompts: list[str] = []
+        dedup_identity: list[dict] = []
+
+        def counting_builder(*args, **kwargs):
+            decision = old_builder(*args, **kwargs)
+            builder_calls.append(
+                {
+                    "variation_attempt": kwargs.get("variation_attempt"),
+                    "decision_id": decision.decision_id,
+                    "prompt": decision.prompt,
+                    "style_name": decision.style_name,
+                }
+            )
+            return decision
+
+        def fake_outcome(prompt: str, requested_path: str, **_kwargs):
+            provider_prompts.append(prompt)
+            path = Path(requested_path).with_suffix(".ppm")
+            _write_dhash_fixture(path, flipped_rows=7)
+            attempts = [
+                {
+                    "backend": "pollinations",
+                    "result": "success",
+                    "http_status": 200,
+                    "payload_byte_count": path.stat().st_size,
+                }
+            ]
+            result = types.SimpleNamespace(
+                path=str(path),
+                backend="pollinations",
+                byte_count=path.stat().st_size,
+                backend_attempts=attempts,
+            )
+            return types.SimpleNamespace(
+                result=result,
+                backend_attempts=attempts,
+                error_type="",
+                error_message="",
+                exhausted=False,
+                actual_backend_call_count=1,
+            )
+
+        real_evaluate = safe_module.evaluate_cyprus_visual_candidate if hasattr(
+            safe_module, "evaluate_cyprus_visual_candidate"
+        ) else cyprus_visual_dedup.evaluate_cyprus_visual_candidate
+        old_evaluate = cyprus_visual_dedup.evaluate_cyprus_visual_candidate
+
+        def recording_evaluate(image_path, **kwargs):
+            dedup_identity.append(
+                {
+                    "selected_scene": kwargs.get("selected_scene"),
+                    "composition": kwargs.get("composition"),
+                    "visual_archetype": kwargs.get("visual_archetype"),
+                    "prompt_version": kwargs.get("prompt_version"),
+                }
+            )
+            return old_evaluate(image_path, **kwargs)
+
+        class FakeBot:
+            def __init__(self, token: str) -> None:
+                assert token == "fixture-token"
+
+            async def send_photo(self, **kwargs):
+                kwargs["photo"].read()
+                return types.SimpleNamespace(message_id=90210)
+
+        try:
+            os.environ.update(
+                {
+                    "CHANNEL_ID": "777",
+                    "CY_SAFE_IMAGE_DIR": str(tmp / "images"),
+                    "CY_IMG_MIN_BYTES": "10",
+                    "CY_IMAGE_DELIVERY_DIR": str(tmp / "cy_image_delivery"),
+                    "CY_TEXT_DELIVERY_DIR": str(tmp / "cy_text_delivery"),
+                    "CY_IMAGE_DIAGNOSTICS_DIR": str(tmp / "cy_image_diagnostics"),
+                    "CY_IMAGE_PROVIDER_HEALTH_DIR": str(tmp / "cy_image_provider_health"),
+                }
+            )
+            cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH = history_path
+            cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH = test_history_path
+            safe_module.TOKEN = "fixture-token"
+            safe_module.Bot = FakeBot
+            imagegen.generate_astro_image_outcome_with_exclusions = fake_outcome
+            imagegen.configured_image_backends = lambda **_kwargs: {
+                "configured_backends": ["pollinations"],
+                "available_backends": ["pollinations"],
+                "unconfigured_backends": [],
+            }
+            image_prompt_cy_scene.build_cyprus_visual_decision = counting_builder
+            cyprus_visual_dedup.evaluate_cyprus_visual_candidate = recording_evaluate
+
+            result = await safe_module._build_safe_test_image(
+                EVENING_MESSAGE,
+                "evening",
+                generate_image=True,
+                send_image_to_test=False,
+                send_image_to_chat=True,
+                image_chat_id=777,
+                image_only_recovery=False,
+            )
+            # Resolve receipt path while the fixture environment is still active.
+            receipt_path = safe_module._cy_image_receipt_path("2026-07-16", "evening")
+        finally:
+            image_prompt_cy_scene.build_cyprus_visual_decision = old_builder
+            cyprus_visual_dedup.evaluate_cyprus_visual_candidate = old_evaluate
+            imagegen.generate_astro_image_outcome_with_exclusions = old_outcome
+            imagegen.configured_image_backends = old_availability
+            safe_module.TOKEN = old_token
+            safe_module.Bot = old_bot
+            cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_PROD_PATH = old_prod_history
+            cyprus_visual_dedup.CYPRUS_VISUAL_HISTORY_TEST_PATH = old_test_history
+            for name, value in old_env.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+
+        assert result["result"] == "sent"
+        # Exactly one decision was built for the single accepted candidate.
+        assert len(builder_calls) == 1, builder_calls
+        decision_id = builder_calls[0]["decision_id"]
+        assert decision_id
+
+        metadata = result["metadata"]
+        assert metadata["decision_id"] == decision_id
+
+        # The provider received exactly the decision's prompt, unmodified.
+        assert len(provider_prompts) == 1
+        assert provider_prompts[0] == builder_calls[0]["prompt"]
+        assert result["style_name"] == builder_calls[0]["style_name"]
+
+        # Dedup ran on the identity carried by that same decision.
+        assert dedup_identity
+        assert dedup_identity[0]["selected_scene"] == metadata["selected_scene"]
+        assert dedup_identity[0]["composition"] == metadata["composition"]
+        assert dedup_identity[0]["visual_archetype"] == metadata["visual_archetype"]
+
+        # History, receipt and diagnostics all report that identity.
+        receipt = json.loads(receipt_path.read_text("utf-8"))
+        history_entries = json.loads(history_path.read_text("utf-8"))
+        assert len(history_entries) == 1
+        diagnostics = json.loads(
+            (tmp / "cy_image_diagnostics" / "2026-07-16-evening" / "image_result.json").read_text("utf-8")
+        )
+        for field in ("selected_scene", "composition", "visual_archetype", "cache_key"):
+            assert receipt[field] == metadata[field], field
+            assert history_entries[0][field] == metadata[field], field
+        assert receipt["style_name"] == metadata["style_name"]
+        assert diagnostics["decision_id"] == decision_id
+        assert diagnostics["prompt_metadata"]["cache_key"] == metadata["cache_key"]
+
+        # A real network image must not be attributed to the local renderer.
+        assert diagnostics["actual_provider"] == "pollinations"
+        assert diagnostics["actual_renderer"] == ""
+        assert diagnostics["fallback_state"] == "network_fallback_not_used"
+        assert diagnostics["error_stage"] == "none"
+        assert diagnostics["routing_inputs"]["primary_weather"] == metadata["primary_weather"]
+        assert "blocked_scenes" in diagnostics["cooldown_inputs"]
+
+    with tempfile.TemporaryDirectory() as tmp_name:
+        asyncio.run(run_case(Path(tmp_name)))
+
+
 def main() -> None:
     checks = (
         local_informative_cover_is_valid_deterministic_and_factual,
@@ -1090,6 +1352,8 @@ def main() -> None:
         primary_evening_incident_sends_local_visual_before_text,
         image_receipt_recheck_closes_primary_and_recovery_send_race,
         informative_cover_failure_falls_through_to_text_without_stale_image,
+        local_cover_reuses_precomputed_context_without_reparse,
+        canonical_decision_is_not_rebuilt_after_provider_success,
     )
     for check in checks:
         check()

--- a/tools/test_cyprus_visual_workflow.py
+++ b/tools/test_cyprus_visual_workflow.py
@@ -1002,6 +1002,95 @@ def test_pillow_is_bounded_dependency() -> None:
     print("PASS pillow_is_bounded_dependency")
 
 
+def _load_legacy_image_guard():
+    """Import only the guard helper from post_cy without importing its heavy deps."""
+    source = (ROOT / "post_cy.py").read_text("utf-8")
+    start = source.index("class legacy_cy_images_disabled:")
+    end = source.index("def _env_true(", start)
+    namespace: dict = {"os": os, "Optional": object}
+    exec(compile(source[start:end], "post_cy_guard", "exec"), namespace)  # noqa: S102
+    return namespace["legacy_cy_images_disabled"]
+
+
+def test_legacy_post_cy_disables_post_common_image_pipeline() -> None:
+    """The legacy text path must not let post_common publish a production image."""
+    guard = _load_legacy_image_guard()
+    previous = os.environ.get("CY_IMG_ENABLED")
+    try:
+        # Case 1: an explicit value is restored verbatim.
+        os.environ["CY_IMG_ENABLED"] = "1"
+        with guard():
+            _assert(
+                "legacy guard disables images",
+                os.environ["CY_IMG_ENABLED"] == "0",
+                os.environ["CY_IMG_ENABLED"],
+            )
+        _assert(
+            "legacy guard restores value",
+            os.environ["CY_IMG_ENABLED"] == "1",
+            os.environ["CY_IMG_ENABLED"],
+        )
+
+        # Case 2: an unset variable stays unset afterwards.
+        os.environ.pop("CY_IMG_ENABLED", None)
+        with guard():
+            _assert(
+                "legacy guard disables images when unset",
+                os.environ["CY_IMG_ENABLED"] == "0",
+                os.environ.get("CY_IMG_ENABLED", "<missing>"),
+            )
+        _assert(
+            "legacy guard leaves variable unset",
+            "CY_IMG_ENABLED" not in os.environ,
+            os.environ.get("CY_IMG_ENABLED", "<missing>"),
+        )
+    finally:
+        if previous is None:
+            os.environ.pop("CY_IMG_ENABLED", None)
+        else:
+            os.environ["CY_IMG_ENABLED"] = previous
+
+
+def test_legacy_post_cy_restores_env_after_exception() -> None:
+    """A failure inside the legacy call must still restore the environment."""
+    guard = _load_legacy_image_guard()
+    previous = os.environ.get("CY_IMG_ENABLED")
+    try:
+        os.environ["CY_IMG_ENABLED"] = "1"
+        raised = False
+        try:
+            with guard():
+                _assert(
+                    "legacy guard disables images before failure",
+                    os.environ["CY_IMG_ENABLED"] == "0",
+                    os.environ["CY_IMG_ENABLED"],
+                )
+                raise RuntimeError("legacy main_common failed")
+        except RuntimeError:
+            raised = True
+        _assert("legacy guard propagates the failure", raised)
+        _assert(
+            "legacy guard restores value after failure",
+            os.environ["CY_IMG_ENABLED"] == "1",
+            os.environ["CY_IMG_ENABLED"],
+        )
+    finally:
+        if previous is None:
+            os.environ.pop("CY_IMG_ENABLED", None)
+        else:
+            os.environ["CY_IMG_ENABLED"] = previous
+
+    # The guard must actually wrap the legacy main_common call site.
+    source = (ROOT / "post_cy.py").read_text("utf-8")
+    guard_index = source.index("with legacy_cy_images_disabled():")
+    call_index = source.index("await main_common(", guard_index)
+    _assert(
+        "legacy guard wraps main_common",
+        guard_index < call_index < guard_index + 200,
+        f"guard={guard_index} call={call_index}",
+    )
+
+
 TESTS = [
     test_daily_visual_history_cache,
     test_safe_test_visual_history_cache,
@@ -1027,6 +1116,8 @@ TESTS = [
     test_main_morning_0315_restore_skips_duplicate_publication,
     test_simulated_manual_morning_evening_history_chain,
     test_pillow_is_bounded_dependency,
+    test_legacy_post_cy_disables_post_common_image_pipeline,
+    test_legacy_post_cy_restores_env_after_exception,
 ]
 
 

--- a/tools/test_visual_cy.py
+++ b/tools/test_visual_cy.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from datetime import date, timedelta
+import hashlib
 import os
 import re
 import sys
@@ -14,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from visual_context_cy import parse_visual_context_cy
 from visual_rules_cy import apply_visual_rules_cy
+import image_prompt_cy_scene
 from image_prompt_cy_scene import (
     CYPRUS_VISUAL_PROMPT_VERSION,
     _CY_COASTAL_COMPOSITIONS,
@@ -1408,6 +1410,147 @@ def cy_evening_tomorrow_morning_mixed_visibility_stays_mixed() -> None:
     assert metadata["visibility_condition"] == "mixed_visibility"
 
 
+CANONICAL_DECISION_SOURCE = """<b>🌅 Кипр: погода на завтра (27.06.2026)</b>
+🏖 <b>Морские города</b>
+🥵 <b>Ларнака</b>: 34/25 °C • ☀️ ясно • 💨 5.0 м/с (Ю) • 1009 гПа → • 🌊 28
+😎 <b>Лимассол</b>: 33/25 °C • ☀️ ясно • 💨 4.0 м/с (Ю) • 1009 гПа → • 🌊 27
+🏙 <b>Центр и горы</b>
+<b>Никосия</b>: 37/23 °C • ☀️ ясно
+🏭 Воздух: AQI 58 (умеренный)
+"""
+
+
+def cy_canonical_decision_reuses_precomputed_context_without_reparse() -> None:
+    """A supplied context must be used as-is: the parser must not run again."""
+    precomputed = image_prompt_cy_scene.build_visual_context_cy(
+        CANONICAL_DECISION_SOURCE,
+        post_type="evening",
+    )
+
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("visual context was parsed a second time")
+
+    original_parse = image_prompt_cy_scene.parse_visual_context_cy
+    original_build = image_prompt_cy_scene.build_visual_context_cy
+    image_prompt_cy_scene.parse_visual_context_cy = _explode
+    image_prompt_cy_scene.build_visual_context_cy = _explode
+    try:
+        decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+            CANONICAL_DECISION_SOURCE,
+            post_type="evening",
+            visual_context=precomputed,
+        )
+    finally:
+        image_prompt_cy_scene.parse_visual_context_cy = original_parse
+        image_prompt_cy_scene.build_visual_context_cy = original_build
+
+    assert decision.context is precomputed
+
+
+def cy_canonical_decision_matches_legacy_wrapper_output() -> None:
+    """The legacy wrapper and the canonical builder must agree byte-for-byte."""
+    for mode in ("morning", "evening"):
+        for attempt in (0, 1, 3):
+            prompt, style, metadata = build_cyprus_scene_prompt_with_metadata(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+            )
+            decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+            )
+            assert decision.prompt == prompt
+            assert decision.style_name == style
+            assert decision.metadata["cache_key"] == metadata["cache_key"]
+            # A precomputed context must not shift prompt/style/cache identity either.
+            reused = image_prompt_cy_scene.build_cyprus_visual_decision(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+                visual_context=image_prompt_cy_scene.build_visual_context_cy(
+                    CANONICAL_DECISION_SOURCE,
+                    post_type=mode,
+                ),
+            )
+            assert reused.prompt == prompt
+            assert reused.style_name == style
+            assert reused.metadata["cache_key"] == metadata["cache_key"]
+
+
+def cy_canonical_decision_exposes_routing_and_cooldown_inputs() -> None:
+    blocked_scenes = ("protected_bay", "long_sandy_beach")
+    blocked_compositions = ("Low sheltered-water composition led by rocks and shallow water",)
+    blocked_archetypes = ("bay_panorama",)
+    decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+        CANONICAL_DECISION_SOURCE,
+        post_type="evening",
+        variation_attempt=2,
+        blocked_scenes=blocked_scenes,
+        blocked_compositions=blocked_compositions,
+        blocked_archetypes=blocked_archetypes,
+    )
+
+    routing = decision.metadata["routing_inputs"]
+    for key in (
+        "primary_weather",
+        "hazards",
+        "scene_focus",
+        "visual_forecast_period",
+        "visibility_condition",
+        "weather_scenario",
+        "variation_attempt",
+    ):
+        assert key in routing, key
+        assert routing[key] == decision.metadata[key]
+
+    cooldown = decision.metadata["cooldown_inputs"]
+    assert cooldown["blocked_scenes"] == list(blocked_scenes)
+    assert cooldown["blocked_compositions"] == list(blocked_compositions)
+    assert cooldown["blocked_archetypes"] == list(blocked_archetypes)
+
+    assert decision.decision_id
+    identity = decision.identity()
+    assert identity["cache_key"] == decision.metadata["cache_key"]
+    assert identity["style_name"] == decision.style_name
+
+
+def cy_canonical_diagnostics_fields_do_not_change_cache_key() -> None:
+    """Diagnostics-only fields are appended after identity, so they cannot shift it."""
+    for mode in ("morning", "evening"):
+        for attempt in (0, 2):
+            for blocked in ((), ("protected_bay",)):
+                decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+                    CANONICAL_DECISION_SOURCE,
+                    post_type=mode,
+                    variation_attempt=attempt,
+                    blocked_scenes=blocked,
+                )
+                legacy_key = build_cyprus_visual_cache_key(
+                    CANONICAL_DECISION_SOURCE,
+                    post_type=mode,
+                    variation_attempt=attempt,
+                    blocked_scenes=blocked,
+                )
+                assert decision.metadata["cache_key"] == legacy_key
+
+                # The ordered cache key must not mention any diagnostics-only field.
+                for diagnostics_field in (
+                    "decision_id",
+                    "routing_inputs",
+                    "cooldown_inputs",
+                    "style_name",
+                ):
+                    assert f"{diagnostics_field}=" not in legacy_key
+
+                # The style digest is derived from cache_key + prompt only.
+                expected_style_digest = hashlib.sha256(
+                    f"{legacy_key}|{decision.prompt}".encode("utf-8")
+                ).hexdigest()[:8]
+                assert decision.style_name.endswith(expected_style_digest)
+
+
 TESTS = [
     cy_morning_clear_high_uv,
     cy_morning_dust_haze,
@@ -1469,6 +1612,10 @@ TESTS = [
     cy_evening_tomorrow_morning_reduced_visibility_has_no_fog_claim,
     cy_evening_tomorrow_morning_dust_haze_is_dry,
     cy_evening_tomorrow_morning_mixed_visibility_stays_mixed,
+    cy_canonical_decision_reuses_precomputed_context_without_reparse,
+    cy_canonical_decision_matches_legacy_wrapper_output,
+    cy_canonical_decision_exposes_routing_and_cooldown_inputs,
+    cy_canonical_diagnostics_fields_do_not_change_cache_key,
 ]
 
 


### PR DESCRIPTION
## What changed

Consolidate the Cyprus visual lifecycle around a single canonical decision per visual candidate, so the same identity flows through `context → routing → prompt → provider → validation → dedup → diagnostics → history → receipt` without re-parsing the post or reselecting a scene.

**`image_prompt_cy_scene.py`**
- Add the frozen `CyprusVisualDecision` value object (`context`, `prompt`, `style_name`, `metadata`, plus visibility provenance) and the canonical `build_cyprus_visual_decision()` builder.
- The builder takes an optional precomputed `VisualContextCY`; when supplied, the parser is not run again. Callers without one keep the previous parse-on-demand behaviour.
- `build_cyprus_scene_prompt_with_metadata`, `build_cyprus_scene_prompt` and `build_cyprus_visual_cache_key` remain as backward-compatible wrappers over the canonical builder.
- `routing_inputs`, `cooldown_inputs` and a deterministic `decision_id` are appended **after** the ordered cache key, prompt and style digest are already final.

**`safe_test_post.py`**
- Parse the finalized post exactly once; every candidate decision, the local fallback renderer and all diagnostics reuse that context.
- Carry the selected candidate as `(decision, image_path, image_size, duplicate_result, backend)` and reuse the decision verbatim after provider success — no late rebuild or reselection.
- Diagnostics now report `decision_id`, `routing_inputs`, `cooldown_inputs`, `actual_provider`, `actual_renderer`, `fallback_state` and `error_stage` (fixed vocabulary). A local cover is never attributed to a network provider.

**`cyprus_image_recovery.py`**
- `_informative_cover_facts()` and `render_local_informative_cover()` accept optional `visual_context` and `visibility_metadata`; legacy callers keep parsing on demand.
- Visibility provenance is recorded **after** the local cache key is computed.

**`post_cy.py`**
- Add the `legacy_cy_images_disabled` guard around the legacy `main_common()` call so the legacy non-FORMAT_V2 text path cannot publish a production image, restoring `CY_IMG_ENABLED` on both success and exception. `post_common.py` is untouched.

## Why

The visual candidate was previously carried as loose `prompt + style_name + metadata`, and the visual context was parsed repeatedly — once per candidate in the generation loop and again inside the local informative-cover renderer. That allowed the reported identity to drift between provider input, dedup, history, receipt and diagnostics, and made it impossible to tell from diagnostics whether a local cover or a real provider produced an image.

## Scope

Lifecycle consolidation only. This PR does **not** change which image the system selects: scene families, scene catalog, weather→scene routing, scene/composition/archetype cooldowns, `least_recently_used` policy, provider order and call limits, image validation, content guard, perceptual dedup, prompt version, history/receipt/provider-health namespaces and schemas, text generation, post structure, editorial voice, lunar/astro logic, and workflows are all untouched.

## Validation

All checks offline with outbound sockets blocked.

- `python -m compileall` passed for all 7 changed files.
- 3 focused suites: `test_visual_cy` 64, `test_cyprus_image_fallback` 9, `test_cyprus_visual_workflow` 26.
- All 12 Cyprus PR-CI suites passed, 274 counted checks plus `test_air_cy`.
- Every suite re-run under a `socket.connect` guard: zero outbound connections.
- `git diff --check` passed.

Invariants proved against the untouched `main` tree:

- Cyprus visual cache key, style name, prompt hash and cache digest are **byte-for-byte identical** across 12 mode/attempt/blocked combinations (48 compared values).
- Local informative fallback cache key and renderer version unchanged for the same factual inputs.
- Canonical identity (`decision_id`, `selected_scene`, `composition`, `visual_archetype`, `style_name`, `cache_key`) matches across provider, dedup, history, receipt and diagnostics.

New regressions were mutation-tested and each one fails when its invariant is broken: re-parsing a supplied context, rebuilding the decision after provider success, removing the legacy image guard, and failing to restore the environment on exception.

Diff is limited to `image_prompt_cy_scene.py`, `safe_test_post.py`, `cyprus_image_recovery.py`, `post_cy.py`, `tools/test_visual_cy.py`, `tools/test_cyprus_image_fallback.py` and `tools/test_cyprus_visual_workflow.py`. Existing fixtures were not rewritten and `data/safecast_cy.json` is exactly as on `main`.

No Telegram, weather/air/marine/Safecast or image-provider call, no manual workflow dispatch, and no publication was run.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQzvEeLyJ1YMaEhoggbPv)_