### PR TITLE
G.1: add Cyprus macro visual identity policy above scene selection

### DIFF
--- a/cyprus_visual_dedup.py
+++ b/cyprus_visual_dedup.py
@@ -14,6 +14,14 @@ import os
 from pathlib import Path
 from typing import Any, Iterable
 
+from cyprus_visual_policy import (
+    CYPRUS_MACRO_COOLDOWN_REASON,
+    cyprus_macro_family_from_entry,
+    cyprus_scene_macro_family,
+    macro_family_is_saturated,
+    recent_real_visual_entries,
+)
+
 
 CYPRUS_VISUAL_HISTORY_PATH = Path(
     os.getenv("CYPRUS_VISUAL_HISTORY_PATH", ".cache/cyprus_visual_history_prod.json")
@@ -523,6 +531,30 @@ def evaluate_cyprus_visual_candidate(
                     matched_entry=entry,
                 )
 
+    # Final macro diversity gate. It runs last so the existing exact/perceptual/
+    # archetype/scene/composition priorities are untouched, and it is a hard gate:
+    # the caller's LRU bypass covers only recent_scene_family and recent_composition.
+    macro_candidate = cyprus_scene_macro_family(scene_value)
+    if macro_family_is_saturated(history, macro_candidate):
+        saturating_entry = next(
+            (
+                entry
+                for entry in reversed(recent_real_visual_entries(history))
+                if cyprus_macro_family_from_entry(entry) == macro_candidate
+            ),
+            None,
+        )
+        return CyprusVisualDuplicateResult(
+            accepted=False,
+            reason=CYPRUS_MACRO_COOLDOWN_REASON,
+            sha256=digest,
+            perceptual_hash=perceptual,
+            phash=phash,
+            min_distance=min_distance,
+            min_phash_distance=min_phash_distance,
+            matched_entry=saturating_entry,
+        )
+
     return CyprusVisualDuplicateResult(
         accepted=True,
         reason="accepted",
@@ -565,6 +597,8 @@ def record_cyprus_visual_publication(
         "selected_scene": selected_scene,
         "composition": composition or "",
         "visual_archetype": visual_archetype or "",
+        # Additive field; legacy entries without it derive their macro from the scene.
+        "scene_macro_family": cyprus_scene_macro_family(selected_scene),
         "prompt_version": prompt_version,
         "cache_key": cache_key,
         "style_name": style_name,

--- a/cyprus_visual_policy.py
+++ b/cyprus_visual_policy.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Cyprus macro visual identity policy.
+
+A deterministic, side-effect-free layer that sits *above* the existing
+``selected_scene`` / ``composition`` / ``visual_archetype`` pipeline. It groups the
+existing Cyprus scene families into a small number of macro families so the channel
+does not show the same kind of place too often, even when the underlying scene,
+composition and archetype all differ.
+
+Macro identity never replaces ``visual_archetype`` and never selects a scene: the
+existing weather-aware selection stays authoritative. This module only classifies
+what was already selected and answers "is this macro family over-used right now".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+# Technical (non-geographic) macro identities.
+CYPRUS_MACRO_LOCAL_COVER = "local_cover"
+CYPRUS_MACRO_UNKNOWN = "unknown"
+
+# The local informative cover is a renderer, not a place, so it carries its own
+# technical macro identity and must never occupy a real-scenery macro window.
+CYPRUS_LOCAL_COVER_SCENES = frozenset({"local_informative_cover", CYPRUS_MACRO_LOCAL_COVER})
+
+# Authoritative scene -> macro family mapping. Every existing Cyprus scene family
+# (coastal and inland) is covered exactly once.
+CYPRUS_SCENE_MACRO_FAMILIES: dict[str, str] = {
+    # rocky natural coast
+    "rocky_cove_overlook": "rocky_natural_coast",
+    "open_sea_cliffs": "rocky_natural_coast",
+    "protected_bay": "rocky_natural_coast",
+    "windy_exposed_coast": "rocky_natural_coast",
+    "quiet_blue_lagoon": "rocky_natural_coast",
+    # open sandy coast
+    "long_sandy_beach": "open_sandy_coast",
+    "open_beach_horizon": "open_sandy_coast",
+    # urban seafront
+    "coastal_promenade": "urban_seafront",
+    "coastal_urban_rooftop": "urban_seafront",
+    "beach_cafe_terrace": "urban_seafront",
+    # harbour / marina
+    "marina_walkway": "harbour_marina",
+    "small_harbour": "harbour_marina",
+    "harbour_pier_waterlevel": "harbour_marina",
+    "breakwater_coast": "harbour_marina",
+    # mountain / inland landscape
+    "mountain_coast_view": "mountain_inland",
+    "troodos_landscape": "mountain_inland",
+    "dry_inland_landscape": "mountain_inland",
+    # inland urban
+    "inland_urban_rooftop": "urban_inland",
+    # village / cultural
+    "inland_village": "village_cultural",
+    # salt lake flatland
+    "salt_lake_landscape": "salt_lake_flatland",
+}
+
+CYPRUS_MACRO_FAMILIES: tuple[str, ...] = (
+    "rocky_natural_coast",
+    "open_sandy_coast",
+    "urban_seafront",
+    "harbour_marina",
+    "mountain_inland",
+    "urban_inland",
+    "village_cultural",
+    "salt_lake_flatland",
+)
+
+# G.1 activates exactly one macro guard: at most two open sandy coast publications
+# within the last five real visual publications.
+CYPRUS_MACRO_RECENT_WINDOW = 5
+CYPRUS_MACRO_LIMITS: dict[str, int] = {
+    "open_sandy_coast": 2,
+}
+
+# Reject reason emitted by the dedup macro gate. Deliberately distinct from the
+# existing scene/composition reasons because it is a hard gate with no LRU bypass.
+CYPRUS_MACRO_COOLDOWN_REASON = "scene_macro_cooldown"
+
+
+def cyprus_scene_macro_family(scene_family: object) -> str:
+    """Return the macro family for a scene family name.
+
+    The local informative cover maps to ``local_cover``; anything empty or unknown
+    maps deterministically to ``unknown``.
+    """
+    scene = str(scene_family or "").strip()
+    if not scene:
+        return CYPRUS_MACRO_UNKNOWN
+    if scene in CYPRUS_LOCAL_COVER_SCENES:
+        return CYPRUS_MACRO_LOCAL_COVER
+    return CYPRUS_SCENE_MACRO_FAMILIES.get(scene, CYPRUS_MACRO_UNKNOWN)
+
+
+def cyprus_macro_family_from_entry(entry: Mapping[str, Any]) -> str:
+    """Macro family of a history entry, deriving it for legacy entries.
+
+    Entries written before G.1 have no ``scene_macro_family`` field, so the macro is
+    derived from ``selected_scene`` and stays backward compatible.
+    """
+    if not isinstance(entry, Mapping):
+        return CYPRUS_MACRO_UNKNOWN
+    explicit = str(entry.get("scene_macro_family") or "").strip()
+    if explicit:
+        return explicit
+    return cyprus_scene_macro_family(entry.get("selected_scene"))
+
+
+def is_local_cover_entry(entry: Mapping[str, Any]) -> bool:
+    """True when the entry is a local informative cover rather than real scenery."""
+    if not isinstance(entry, Mapping):
+        return False
+    if str(entry.get("selected_scene") or "").strip() in CYPRUS_LOCAL_COVER_SCENES:
+        return True
+    return str(entry.get("scene_macro_family") or "").strip() == CYPRUS_MACRO_LOCAL_COVER
+
+
+def recent_real_visual_entries(
+    history: Iterable[Mapping[str, Any]],
+    limit: int = CYPRUS_MACRO_RECENT_WINDOW,
+) -> list[Mapping[str, Any]]:
+    """Last ``limit`` real visual publications, oldest first.
+
+    Local informative covers are excluded, so a run of provider outages cannot flush
+    the macro window and let an over-used macro family return early.
+    """
+    real = [entry for entry in history if isinstance(entry, Mapping) and not is_local_cover_entry(entry)]
+    if limit <= 0:
+        return []
+    return real[-limit:]
+
+
+def count_recent_macro_family(
+    history: Iterable[Mapping[str, Any]],
+    macro_family: str,
+    limit: int = CYPRUS_MACRO_RECENT_WINDOW,
+) -> int:
+    """How many of the last real publications carry this macro family."""
+    target = str(macro_family or "").strip()
+    if not target or target in {CYPRUS_MACRO_UNKNOWN, CYPRUS_MACRO_LOCAL_COVER}:
+        return 0
+    return sum(
+        1
+        for entry in recent_real_visual_entries(history, limit)
+        if cyprus_macro_family_from_entry(entry) == target
+    )
+
+
+def macro_family_is_saturated(
+    history: Iterable[Mapping[str, Any]],
+    macro_family: str,
+    limit: int = CYPRUS_MACRO_RECENT_WINDOW,
+) -> bool:
+    """True when this macro family already reached its cap in the recent window."""
+    target = str(macro_family or "").strip()
+    cap = CYPRUS_MACRO_LIMITS.get(target)
+    if cap is None:
+        return False
+    return count_recent_macro_family(history, target, limit) >= cap
+
+
+def blocked_macro_families(
+    history: Iterable[Mapping[str, Any]],
+    limit: int = CYPRUS_MACRO_RECENT_WINDOW,
+) -> tuple[str, ...]:
+    """Macro families that are over-used in the recent real-publication window."""
+    entries = list(history)
+    return tuple(
+        family
+        for family in CYPRUS_MACRO_FAMILIES
+        if macro_family_is_saturated(entries, family, limit)
+    )
+
+
+__all__ = [
+    "CYPRUS_LOCAL_COVER_SCENES",
+    "CYPRUS_MACRO_COOLDOWN_REASON",
+    "CYPRUS_MACRO_FAMILIES",
+    "CYPRUS_MACRO_LIMITS",
+    "CYPRUS_MACRO_LOCAL_COVER",
+    "CYPRUS_MACRO_RECENT_WINDOW",
+    "CYPRUS_MACRO_UNKNOWN",
+    "CYPRUS_SCENE_MACRO_FAMILIES",
+    "blocked_macro_families",
+    "count_recent_macro_family",
+    "cyprus_macro_family_from_entry",
+    "cyprus_scene_macro_family",
+    "is_local_cover_entry",
+    "macro_family_is_saturated",
+    "recent_real_visual_entries",
+]

--- a/image_prompt_cy_scene.py
+++ b/image_prompt_cy_scene.py
@@ -12,6 +12,7 @@ from datetime import date, timedelta
 from typing import Any, Mapping
 from urllib.parse import quote_plus
 
+from cyprus_visual_policy import cyprus_scene_macro_family
 from visual_context_cy import VisualContextCY, parse_visual_context_cy
 from visual_rules_cy import SceneCuesCY, apply_visual_rules_cy
 
@@ -638,9 +639,11 @@ def _coastal_visual_variants(
     blocked_scenes: tuple[str, ...] = (),
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
+    blocked_macro_families: tuple[str, ...] = (),
 ) -> dict[str, str]:
     date_key = _extract_date_key(message)
     blocked_archetype_set = {value for value in blocked_archetypes if value}
+    blocked_macro_set = {value for value in blocked_macro_families if value}
     selected: tuple[str, str, str, str, str] | None = None
     attempts = max(1, len(_available_scene_families(_CYPRUS_SCENE_FAMILIES)) * 2)
     for offset in range(attempts):
@@ -675,7 +678,12 @@ def _coastal_visual_variants(
             scene_selection_mode,
             composition_selection_mode,
         )
-        if visual_archetype not in blocked_archetype_set:
+        # An over-used macro family keeps the existing candidate search going; the
+        # weather-aware selection above stays authoritative for what is offered.
+        if (
+            visual_archetype not in blocked_archetype_set
+            and cyprus_scene_macro_family(scene_family) not in blocked_macro_set
+        ):
             break
     assert selected is not None
     (
@@ -1142,6 +1150,7 @@ def _visual_cache_metadata(
     blocked_scenes: tuple[str, ...] = (),
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
+    blocked_macro_families: tuple[str, ...] = (),
 ) -> dict[str, object]:
     forecast_date = _extract_date_key(message)
     if ctx.scene_focus == "inland":
@@ -1165,6 +1174,7 @@ def _visual_cache_metadata(
             blocked_scenes=blocked_scenes,
             blocked_compositions=blocked_compositions,
             blocked_archetypes=blocked_archetypes,
+            blocked_macro_families=blocked_macro_families,
         )
         selected_scene = variants["scene_family"]
         composition = variants["composition"]
@@ -1249,6 +1259,10 @@ def _visual_cache_metadata(
     )
     metadata["cache_key"] = "|".join(f"{key}={metadata[key]}" for key in ordered)
     metadata["cache_digest"] = hashlib.sha256(metadata["cache_key"].encode("utf-8")).hexdigest()[:12]
+    # Macro identity is an additive diagnostics/history field only. It is assigned
+    # after the ordered cache key above, and it is deliberately absent from `ordered`,
+    # so the existing cache identity stays byte-for-byte unchanged.
+    metadata["scene_macro_family"] = cyprus_scene_macro_family(selected_scene)
     return metadata
 
 
@@ -1260,6 +1274,7 @@ def build_cyprus_visual_cache_key(
     blocked_scenes: tuple[str, ...] = (),
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
+    blocked_macro_families: tuple[str, ...] = (),
     visibility_metadata: Mapping[str, Any] | None = None,
 ) -> str:
     mode = post_type.strip().lower()
@@ -1278,6 +1293,7 @@ def build_cyprus_visual_cache_key(
         blocked_scenes=blocked_scenes,
         blocked_compositions=blocked_compositions,
         blocked_archetypes=blocked_archetypes,
+        blocked_macro_families=blocked_macro_families,
     )["cache_key"]
 
 
@@ -1344,6 +1360,7 @@ def build_cyprus_visual_decision(
     blocked_scenes: tuple[str, ...] = (),
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
+    blocked_macro_families: tuple[str, ...] = (),
     visibility_metadata: Mapping[str, Any] | None = None,
     visual_context: VisualContextCY | None = None,
 ) -> CyprusVisualDecision:
@@ -1380,6 +1397,7 @@ def build_cyprus_visual_decision(
         blocked_scenes=blocked_scenes,
         blocked_compositions=blocked_compositions,
         blocked_archetypes=blocked_archetypes,
+        blocked_macro_families=blocked_macro_families,
     )
     positive = [
         "Photorealistic natural Cyprus landscape photography",
@@ -1430,6 +1448,7 @@ def build_cyprus_visual_decision(
         "blocked_scenes": list(blocked_scenes),
         "blocked_compositions": list(blocked_compositions),
         "blocked_archetypes": list(blocked_archetypes),
+        "blocked_macro_families": list(blocked_macro_families),
     }
     metadata["decision_id"] = hashlib.sha256(
         "|".join(
@@ -1458,6 +1477,7 @@ def build_cyprus_scene_prompt_with_metadata(
     blocked_scenes: tuple[str, ...] = (),
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
+    blocked_macro_families: tuple[str, ...] = (),
     visibility_metadata: Mapping[str, Any] | None = None,
 ) -> tuple[str, str, dict[str, object]]:
     """Return a sanitized Cyprus prompt, stable style name, and visual cache metadata."""
@@ -1468,6 +1488,7 @@ def build_cyprus_scene_prompt_with_metadata(
         blocked_scenes=blocked_scenes,
         blocked_compositions=blocked_compositions,
         blocked_archetypes=blocked_archetypes,
+        blocked_macro_families=blocked_macro_families,
         visibility_metadata=visibility_metadata,
     )
     return decision.prompt, decision.style_name, decision.metadata
@@ -1481,6 +1502,7 @@ def build_cyprus_scene_prompt(
     blocked_scenes: tuple[str, ...] = (),
     blocked_compositions: tuple[str, ...] = (),
     blocked_archetypes: tuple[str, ...] = (),
+    blocked_macro_families: tuple[str, ...] = (),
     visibility_metadata: Mapping[str, Any] | None = None,
 ) -> tuple[str, str]:
     """Return a sanitized positive Cyprus landscape prompt and stable style name."""
@@ -1491,6 +1513,7 @@ def build_cyprus_scene_prompt(
         blocked_scenes=blocked_scenes,
         blocked_compositions=blocked_compositions,
         blocked_archetypes=blocked_archetypes,
+        blocked_macro_families=blocked_macro_families,
         visibility_metadata=visibility_metadata,
     )
     return prompt, style_name

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -1990,6 +1990,10 @@ async def _build_safe_test_image(
             render_local_informative_cover,
             write_provider_health,
         )
+        from cyprus_visual_policy import (
+            CYPRUS_MACRO_LOCAL_COVER,
+            blocked_macro_families,
+        )
         import image_prompt_cy_scene as visual_decision_module
         from image_prompt_cy_scene import build_visual_context_cy
         from weather import load_cyprus_visibility_diagnostics
@@ -2048,6 +2052,14 @@ async def _build_safe_test_image(
         if "elevated_cliff_panorama" in recent_archetypes[-6:]:
             blocked_archetype_values.append("elevated_cliff_panorama")
         blocked_archetypes = tuple(dict.fromkeys(blocked_archetype_values))
+        # Macro blockers come from the restored history. Local informative covers are
+        # excluded inside the policy, so provider outages cannot flush the macro window.
+        blocked_macro_family_values = blocked_macro_families(restored_history)
+        if blocked_macro_family_values:
+            print(
+                "CY_SAFE_IMAGE_BLOCKED_MACRO_FAMILIES: "
+                + ",".join(blocked_macro_family_values)
+            )
         print(f"CY_SAFE_IMAGE_HISTORY_NAMESPACE: {history_namespace}")
         print(f"CY_SAFE_IMAGE_WRITE_HISTORY_PATH: {write_history_path}")
         print("CY_SAFE_IMAGE_REFERENCE_HISTORY_PATHS: " + ", ".join(map(str, reference_history_paths)))
@@ -2135,6 +2147,7 @@ async def _build_safe_test_image(
                 blocked_scenes=recent_scene_values,
                 blocked_compositions=recent_composition_values,
                 blocked_archetypes=blocked_archetypes,
+                blocked_macro_families=blocked_macro_family_values,
                 visibility_metadata=visibility_metadata,
                 visual_context=canonical_visual_context,
             )
@@ -2571,6 +2584,9 @@ async def _build_safe_test_image(
                         "selected_scene": "local_informative_cover",
                         "composition": "informative_cover",
                         "visual_archetype": "factual_weather_cover",
+                        # The local cover is a renderer, not a place: it carries the
+                        # technical macro and never inherits the network macro.
+                        "scene_macro_family": CYPRUS_MACRO_LOCAL_COVER,
                         "scene_selection_mode": "local_fallback",
                         "composition_selection_mode": "local_fallback",
                     }
@@ -2628,6 +2644,7 @@ async def _build_safe_test_image(
                     # The renderer's cache key is already final at this point, so the local
                     # decision_id below is diagnostics-only and cannot affect it.
                     local_metadata["style_name"] = _CY_LOCAL_RENDERER_NAME
+                    local_metadata["scene_macro_family"] = CYPRUS_MACRO_LOCAL_COVER
                     local_metadata["decision_id"] = _cy_local_decision_id(local_metadata)
                     local_sha256 = sha256_file(local_path)
                     existing_local_exact = next(
@@ -2920,6 +2937,8 @@ async def _build_safe_test_image(
                     "selected_scene": metadata["selected_scene"],
                     "composition": metadata.get("composition", ""),
                     "visual_archetype": metadata.get("visual_archetype", ""),
+                    # Additive only; no other receipt field changes meaning.
+                    "scene_macro_family": metadata.get("scene_macro_family", ""),
                     "style_name": style_name,
                     "cache_key": metadata["cache_key"],
                     "backend": selected_backend,

--- a/tools/test_cyprus_image_fallback.py
+++ b/tools/test_cyprus_image_fallback.py
@@ -735,6 +735,21 @@ def primary_evening_incident_sends_local_visual_before_text() -> None:
             if "style_name" in local_history[0]:
                 assert local_history[0]["style_name"] == receipt["style_name"]
 
+            # G.1: the local cover carries the technical macro and never inherits the
+            # network macro, across metadata, diagnostics, history and receipt.
+            assert local_metadata["scene_macro_family"] == "local_cover"
+            assert receipt["scene_macro_family"] == "local_cover"
+            assert local_history[0]["scene_macro_family"] == "local_cover"
+            network_macros = {
+                str(entry.get("scene_macro_family") or "")
+                for entry in history_entries
+                if str(entry.get("selected_scene")) != "local_informative_cover"
+            }
+            assert "local_cover" not in network_macros
+            assert local_metadata["scene_macro_family"] not in {
+                macro for macro in network_macros if macro
+            }
+
             local_decision_id = local_metadata["decision_id"]
             assert local_decision_id
             assert diagnostics["decision_id"] == local_decision_id
@@ -765,6 +780,9 @@ def primary_evening_incident_sends_local_visual_before_text() -> None:
                 )
             assert probe["metadata"]["cache_key"] == local_metadata["cache_key"]
             assert probe["metadata"]["renderer_version"] == LOCAL_INFORMATIVE_COVER_VERSION
+            # G.1 must not touch the local renderer version or its cache identity.
+            assert LOCAL_INFORMATIVE_COVER_VERSION == "cy_local_informative_cover_v3"
+            assert "scene_macro_family" not in probe["metadata"]
 
             amain_source = inspect.getsource(safe_module.main)
             image_index = amain_source.index("image_result = await _build_safe_test_image(")
@@ -1377,6 +1395,16 @@ def canonical_decision_is_not_rebuilt_after_provider_success() -> None:
         assert diagnostics["error_stage"] == "none"
         assert diagnostics["routing_inputs"]["primary_weather"] == metadata["primary_weather"]
         assert "blocked_scenes" in diagnostics["cooldown_inputs"]
+        assert "blocked_macro_families" in diagnostics["cooldown_inputs"]
+
+        # G.1: a network image carries a real macro family, shared by receipt/history.
+        from cyprus_visual_policy import cyprus_scene_macro_family
+
+        network_macro = metadata["scene_macro_family"]
+        assert network_macro == cyprus_scene_macro_family(metadata["selected_scene"])
+        assert network_macro not in {"local_cover", "unknown"}
+        assert receipt["scene_macro_family"] == network_macro
+        assert history_entries[0]["scene_macro_family"] == network_macro
 
     with tempfile.TemporaryDirectory() as tmp_name:
         asyncio.run(run_case(Path(tmp_name)))

--- a/tools/test_cyprus_visual_dedup.py
+++ b/tools/test_cyprus_visual_dedup.py
@@ -509,6 +509,276 @@ def cy_bay_archetype_cooldown_uses_last_ten_references() -> None:
         shutil.rmtree(root, ignore_errors=True)
 
 
+def _seed_macro_history(
+    history: Path,
+    root: Path,
+    scenes: list[str],
+    *,
+    start_day: int = 1,
+) -> None:
+    """Write one history entry per scene, each with a distinct image and composition."""
+    for index, scene in enumerate(scenes):
+        image = root / f"seed_{index}.ppm"
+        _write_ppm(image, mode="coast_a" if index % 2 == 0 else "coast_b", tint=index * 7 + 3)
+        record_cyprus_visual_publication(
+            date_value=f"2026-06-{start_day + index:02d}",
+            post_type="morning",
+            image_path=image,
+            selected_scene=scene,
+            prompt_version="cyprus_visual_v_test",
+            cache_key=f"cache={scene}-{index}",
+            style_name=f"style_{index}",
+            composition=f"composition variant {index}",
+            visual_archetype=f"archetype_{index}",
+            history_path=history,
+        )
+
+
+def cy_macro_third_sandy_candidate_is_rejected_with_scene_macro_cooldown() -> None:
+    """Two sandy publications in the last five real entries block a third."""
+    root = _tmpdir()
+    try:
+        history = root / "history.json"
+        _seed_macro_history(
+            history,
+            root,
+            [
+                "long_sandy_beach",
+                "coastal_promenade",
+                "open_beach_horizon",
+                "marina_walkway",
+                "troodos_landscape",
+            ],
+        )
+        candidate = root / "candidate.ppm"
+        _write_ppm(candidate, mode="coast_b", tint=131)
+        result = evaluate_cyprus_visual_candidate(
+            candidate,
+            date_value="2026-06-20",
+            post_type="evening",
+            selected_scene="long_sandy_beach",
+            prompt_version="cyprus_visual_v_test",
+            composition="a brand new composition",
+            visual_archetype="beach_eye_level",
+            history_path=history,
+        )
+        assert result.accepted is False
+        assert result.reason == "scene_macro_cooldown"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def cy_macro_non_sandy_candidate_passes_the_same_history() -> None:
+    """The macro gate is family-scoped: a different macro still passes."""
+    root = _tmpdir()
+    try:
+        history = root / "history.json"
+        _seed_macro_history(
+            history,
+            root,
+            [
+                "long_sandy_beach",
+                "coastal_promenade",
+                "open_beach_horizon",
+                "marina_walkway",
+                "troodos_landscape",
+            ],
+        )
+        candidate = root / "candidate.ppm"
+        _write_ppm(candidate, mode="coast_b", tint=137)
+        result = evaluate_cyprus_visual_candidate(
+            candidate,
+            date_value="2026-06-20",
+            post_type="evening",
+            selected_scene="open_sea_cliffs",
+            prompt_version="cyprus_visual_v_test",
+            composition="another brand new composition",
+            visual_archetype="open_sea_shore",
+            history_path=history,
+        )
+        assert result.accepted is True, result.reason
+        assert result.reason == "accepted"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def cy_macro_local_covers_do_not_occupy_the_macro_window() -> None:
+    """Local covers must not push sandy entries out of the recent real window."""
+    root = _tmpdir()
+    try:
+        history = root / "history.json"
+        _seed_macro_history(
+            history,
+            root,
+            [
+                "long_sandy_beach",
+                "open_beach_horizon",
+                "local_informative_cover",
+                "local_informative_cover",
+                "local_informative_cover",
+                "local_informative_cover",
+            ],
+        )
+        candidate = root / "candidate.ppm"
+        _write_ppm(candidate, mode="coast_a", tint=151)
+        result = evaluate_cyprus_visual_candidate(
+            candidate,
+            date_value="2026-06-20",
+            post_type="evening",
+            selected_scene="long_sandy_beach",
+            prompt_version="cyprus_visual_v_test",
+            composition="yet another composition",
+            visual_archetype="beach_eye_level",
+            history_path=history,
+        )
+        # The four local covers are skipped, so both sandy entries still count.
+        assert result.accepted is False
+        assert result.reason == "scene_macro_cooldown"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def cy_macro_legacy_history_without_macro_field_still_works() -> None:
+    """Entries written before G.1 derive their macro from selected_scene."""
+    root = _tmpdir()
+    try:
+        history = root / "history.json"
+        legacy = []
+        # Ordered so the sandy entries have already left the 3-entry scene window and
+        # the newest entry has a different archetype: only the macro gate can fire.
+        legacy_scenes = (
+            "long_sandy_beach",
+            "open_beach_horizon",
+            "coastal_promenade",
+            "marina_walkway",
+            "troodos_landscape",
+        )
+        for index, scene in enumerate(legacy_scenes):
+            image = root / f"legacy_{index}.ppm"
+            _write_ppm(image, mode="coast_a", tint=index * 11 + 5)
+            legacy.append(
+                {
+                    "date": f"2026-06-{10 + index:02d}",
+                    "post_type": "morning",
+                    "sha256": f"legacy-sha-{index}",
+                    "perceptual_hash": "",
+                    "phash": "",
+                    "selected_scene": scene,
+                    "composition": f"legacy composition {index}",
+                    "visual_archetype": "",
+                    "prompt_version": "cyprus_visual_v_test",
+                    "cache_key": f"legacy-cache-{index}",
+                    "style_name": f"legacy_style_{index}",
+                    # deliberately no scene_macro_family
+                }
+            )
+        save_cyprus_visual_history(legacy, history)
+        assert all("scene_macro_family" not in entry for entry in load_cyprus_visual_history(history))
+
+        candidate = root / "candidate.ppm"
+        _write_ppm(candidate, mode="coast_b", tint=163)
+        result = evaluate_cyprus_visual_candidate(
+            candidate,
+            date_value="2026-06-20",
+            post_type="evening",
+            selected_scene="long_sandy_beach",
+            prompt_version="cyprus_visual_v_test",
+            composition="fresh composition",
+            visual_archetype="beach_eye_level",
+            history_path=history,
+        )
+        assert result.accepted is False
+        assert result.reason == "scene_macro_cooldown"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def cy_macro_new_history_entry_records_macro_family() -> None:
+    root = _tmpdir()
+    try:
+        history = root / "history.json"
+        image = root / "published.ppm"
+        _write_ppm(image, mode="coast_a", tint=59)
+        entry = record_cyprus_visual_publication(
+            date_value="2026-06-21",
+            post_type="evening",
+            image_path=image,
+            selected_scene="small_harbour",
+            prompt_version="cyprus_visual_v_test",
+            cache_key="cache=harbour",
+            style_name="style_harbour",
+            composition="harbour composition",
+            visual_archetype="harbour_pier",
+            history_path=history,
+        )
+        assert entry["scene_macro_family"] == "harbour_marina"
+        stored = load_cyprus_visual_history(history)[-1]
+        assert stored["scene_macro_family"] == "harbour_marina"
+        # Existing fields keep their meaning.
+        assert stored["selected_scene"] == "small_harbour"
+        assert stored["visual_archetype"] == "harbour_pier"
+
+        local_image = root / "local.ppm"
+        _write_ppm(local_image, mode="coast_b", tint=61)
+        local_entry = record_cyprus_visual_publication(
+            date_value="2026-06-22",
+            post_type="evening",
+            image_path=local_image,
+            selected_scene="local_informative_cover",
+            prompt_version="cy_local_informative_cover_v3",
+            cache_key="cache=local",
+            style_name="local_informative_cover",
+            composition="informative_cover",
+            visual_archetype="factual_weather_cover",
+            history_path=history,
+        )
+        assert local_entry["scene_macro_family"] == "local_cover"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def cy_macro_gate_runs_after_existing_rejection_priorities() -> None:
+    """Existing exact/scene/composition reasons still win over the macro gate."""
+    root = _tmpdir()
+    try:
+        history = root / "history.json"
+        _seed_macro_history(
+            history,
+            root,
+            ["long_sandy_beach", "coastal_promenade", "open_beach_horizon"],
+        )
+        # Exact duplicate of a sandy entry: must report exact_duplicate, not macro.
+        exact = root / "seed_0.ppm"
+        exact_result = evaluate_cyprus_visual_candidate(
+            exact,
+            date_value="2026-06-20",
+            post_type="evening",
+            selected_scene="long_sandy_beach",
+            prompt_version="cyprus_visual_v_test",
+            composition="a distinct composition",
+            visual_archetype="beach_eye_level",
+            history_path=history,
+        )
+        assert exact_result.reason == "exact_duplicate"
+
+        # Repeating the most recent scene family must still report recent_scene_family.
+        scene_repeat = root / "scene_repeat.ppm"
+        _write_ppm(scene_repeat, mode="coast_b", tint=173)
+        scene_result = evaluate_cyprus_visual_candidate(
+            scene_repeat,
+            date_value="2026-06-20",
+            post_type="evening",
+            selected_scene="open_beach_horizon",
+            prompt_version="cyprus_visual_v_test",
+            composition="a different composition again",
+            visual_archetype="beach_eye_level",
+            history_path=history,
+        )
+        assert scene_result.reason == "recent_scene_family"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
 TESTS = [
     cy_dedup_exact_sha_is_rejected,
     cy_dedup_near_duplicate_recolor_crop_is_rejected,
@@ -523,6 +793,12 @@ TESTS = [
     cy_dedup_recent_composition_is_rejected,
     cy_test_reference_reads_prod_but_writes_test_only,
     cy_bay_archetype_cooldown_uses_last_ten_references,
+    cy_macro_third_sandy_candidate_is_rejected_with_scene_macro_cooldown,
+    cy_macro_non_sandy_candidate_passes_the_same_history,
+    cy_macro_local_covers_do_not_occupy_the_macro_window,
+    cy_macro_legacy_history_without_macro_field_still_works,
+    cy_macro_new_history_entry_records_macro_family,
+    cy_macro_gate_runs_after_existing_rejection_priorities,
 ]
 
 

--- a/tools/test_visual_cy.py
+++ b/tools/test_visual_cy.py
@@ -16,8 +16,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from visual_context_cy import parse_visual_context_cy
 from visual_rules_cy import apply_visual_rules_cy
 import image_prompt_cy_scene
+from cyprus_visual_policy import cyprus_scene_macro_family
 from image_prompt_cy_scene import (
     CYPRUS_VISUAL_PROMPT_VERSION,
+    _CYPRUS_SCENE_FAMILIES,
     _CY_COASTAL_COMPOSITIONS,
     _CY_SCENE_COMPOSITIONS,
     _dedupe_semantic_items,
@@ -1551,6 +1553,183 @@ def cy_canonical_diagnostics_fields_do_not_change_cache_key() -> None:
                 assert decision.style_name.endswith(expected_style_digest)
 
 
+MACRO_SANDY_SCENES = ("long_sandy_beach", "open_beach_horizon")
+
+
+def cy_macro_taxonomy_covers_every_scene_family() -> None:
+    """Every existing Cyprus scene family maps to its expected macro."""
+    expected = {
+        "rocky_cove_overlook": "rocky_natural_coast",
+        "open_sea_cliffs": "rocky_natural_coast",
+        "protected_bay": "rocky_natural_coast",
+        "windy_exposed_coast": "rocky_natural_coast",
+        "quiet_blue_lagoon": "rocky_natural_coast",
+        "long_sandy_beach": "open_sandy_coast",
+        "open_beach_horizon": "open_sandy_coast",
+        "coastal_promenade": "urban_seafront",
+        "coastal_urban_rooftop": "urban_seafront",
+        "beach_cafe_terrace": "urban_seafront",
+        "marina_walkway": "harbour_marina",
+        "small_harbour": "harbour_marina",
+        "harbour_pier_waterlevel": "harbour_marina",
+        "breakwater_coast": "harbour_marina",
+        "mountain_coast_view": "mountain_inland",
+        "troodos_landscape": "mountain_inland",
+        "dry_inland_landscape": "mountain_inland",
+        "inland_urban_rooftop": "urban_inland",
+        "inland_village": "village_cultural",
+        "salt_lake_landscape": "salt_lake_flatland",
+    }
+    for scene, macro in expected.items():
+        assert cyprus_scene_macro_family(scene) == macro, scene
+
+    # No coastal scene family may be left unclassified.
+    for scene in _CYPRUS_SCENE_FAMILIES:
+        assert scene in expected, scene
+        assert cyprus_scene_macro_family(scene) != "unknown", scene
+
+
+def cy_macro_local_cover_and_unknown_are_deterministic() -> None:
+    assert cyprus_scene_macro_family("local_informative_cover") == "local_cover"
+    assert cyprus_scene_macro_family("local_cover") == "local_cover"
+    assert cyprus_scene_macro_family("") == "unknown"
+    assert cyprus_scene_macro_family(None) == "unknown"
+    assert cyprus_scene_macro_family("no_such_scene_family") == "unknown"
+
+
+def cy_empty_macro_policy_keeps_prompt_style_and_cache_identical() -> None:
+    """An empty macro policy must not disturb the existing selection at all."""
+    for mode in ("morning", "evening"):
+        for attempt in (0, 1, 2, 3):
+            base_prompt, base_style, base_meta = build_cyprus_scene_prompt_with_metadata(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+            )
+            macro_prompt, macro_style, macro_meta = build_cyprus_scene_prompt_with_metadata(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+                blocked_macro_families=(),
+            )
+            assert macro_prompt == base_prompt
+            assert macro_style == base_style
+            assert macro_meta["cache_key"] == base_meta["cache_key"]
+            assert macro_meta["selected_scene"] == base_meta["selected_scene"]
+            assert macro_meta["composition"] == base_meta["composition"]
+
+
+def cy_blocked_sandy_macro_excludes_both_sandy_scenes() -> None:
+    """Blocking open_sandy_coast must exclude both sandy scenes, not just one."""
+    blocked_any = False
+    for mode in ("morning", "evening"):
+        for attempt in range(8):
+            baseline = image_prompt_cy_scene.build_cyprus_visual_decision(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+            )
+            decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+                blocked_macro_families=("open_sandy_coast",),
+            )
+            assert decision.metadata["selected_scene"] not in MACRO_SANDY_SCENES
+            assert decision.metadata["scene_macro_family"] != "open_sandy_coast"
+            if baseline.metadata["selected_scene"] in MACRO_SANDY_SCENES:
+                blocked_any = True
+                # The blocked case must actually have moved to a different scene.
+                assert decision.metadata["selected_scene"] != baseline.metadata["selected_scene"]
+    assert blocked_any, "fixture never selected a sandy scene, regression is vacuous"
+
+
+def cy_macro_blocking_preserves_weather_constraints() -> None:
+    """Macro blocking must not smuggle in a scene the weather rules exclude."""
+    sources = (
+        ("evening", DRY_SEVERE_WIND_SOURCE),
+        ("evening", WET_SEVERE_WIND_SOURCE),
+        ("evening", LOCAL_MOUNTAIN_THUNDER_SOURCE),
+    )
+    for mode, source in sources:
+        final_text = build_evening_format_v2("Кипр", source)
+        for attempt in range(4):
+            unblocked = image_prompt_cy_scene.build_cyprus_visual_decision(
+                final_text, post_type=mode, variation_attempt=attempt
+            )
+            blocked = image_prompt_cy_scene.build_cyprus_visual_decision(
+                final_text,
+                post_type=mode,
+                variation_attempt=attempt,
+                blocked_macro_families=("open_sandy_coast",),
+            )
+            # Weather-derived routing inputs stay identical; only the scene may move.
+            for key in (
+                "weather_scenario",
+                "primary_weather",
+                "hazards",
+                "visual_forecast_period",
+                "scene_focus",
+                "visibility_condition",
+                "wind_gust_category",
+            ):
+                assert blocked.metadata[key] == unblocked.metadata[key], key
+            assert blocked.metadata["selected_scene"] in set(_CYPRUS_SCENE_FAMILIES) | {
+                "inland_urban_rooftop",
+                "troodos_landscape",
+                "inland_village",
+                "dry_inland_landscape",
+            }
+
+
+def cy_metadata_macro_matches_selected_scene() -> None:
+    for mode in ("morning", "evening"):
+        for attempt in range(6):
+            decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=attempt,
+            )
+            assert decision.metadata["scene_macro_family"] == cyprus_scene_macro_family(
+                decision.metadata["selected_scene"]
+            )
+            assert decision.metadata["scene_macro_family"] != "unknown"
+
+
+def cy_cooldown_inputs_include_blocked_macro_families() -> None:
+    decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+        CANONICAL_DECISION_SOURCE,
+        post_type="evening",
+        variation_attempt=1,
+        blocked_scenes=("protected_bay",),
+        blocked_macro_families=("open_sandy_coast", "harbour_marina"),
+    )
+    cooldown = decision.metadata["cooldown_inputs"]
+    assert cooldown["blocked_macro_families"] == ["open_sandy_coast", "harbour_marina"]
+    assert cooldown["blocked_scenes"] == ["protected_bay"]
+
+
+def cy_macro_fields_are_absent_from_the_ordered_cache_key() -> None:
+    """Macro identity is diagnostics/history only and must stay out of cache identity."""
+    for mode in ("morning", "evening"):
+        for blocked in ((), ("open_sandy_coast",)):
+            decision = image_prompt_cy_scene.build_cyprus_visual_decision(
+                CANONICAL_DECISION_SOURCE,
+                post_type=mode,
+                variation_attempt=0,
+                blocked_macro_families=blocked,
+            )
+            cache_key = decision.metadata["cache_key"]
+            assert "scene_macro_family=" not in cache_key
+            assert "blocked_macro_families=" not in cache_key
+            assert decision.metadata["scene_macro_family"] not in cache_key.split("|")
+            # The style digest is still cache_key + prompt only.
+            expected_digest = hashlib.sha256(
+                f"{cache_key}|{decision.prompt}".encode("utf-8")
+            ).hexdigest()[:8]
+            assert decision.style_name.endswith(expected_digest)
+
+
 TESTS = [
     cy_morning_clear_high_uv,
     cy_morning_dust_haze,
@@ -1616,6 +1795,14 @@ TESTS = [
     cy_canonical_decision_matches_legacy_wrapper_output,
     cy_canonical_decision_exposes_routing_and_cooldown_inputs,
     cy_canonical_diagnostics_fields_do_not_change_cache_key,
+    cy_macro_taxonomy_covers_every_scene_family,
+    cy_macro_local_cover_and_unknown_are_deterministic,
+    cy_empty_macro_policy_keeps_prompt_style_and_cache_identical,
+    cy_blocked_sandy_macro_excludes_both_sandy_scenes,
+    cy_macro_blocking_preserves_weather_constraints,
+    cy_metadata_macro_matches_selected_scene,
+    cy_cooldown_inputs_include_blocked_macro_families,
+    cy_macro_fields_are_absent_from_the_ordered_cache_key,
 ]
 
 


### PR DESCRIPTION
## What changed

Add a deterministic **macro visual identity** layer *above* the existing `selected_scene` / `composition` / `visual_archetype` pipeline, so the channel does not repeat the same kind of place too often even when scene, composition and archetype all differ. The existing visual pipeline is not rewritten and selection stays weather-aware.

**`cyprus_visual_policy.py`** (new, side-effect-free)
- Authoritative scene → macro mapping covering all 20 existing Cyprus scene families across 8 macro families (`rocky_natural_coast`, `open_sandy_coast`, `urban_seafront`, `harbour_marina`, `mountain_inland`, `urban_inland`, `village_cultural`, `salt_lake_flatland`).
- Technical identities: `local_informative_cover` → `local_cover`, empty/unrecognised → deterministic `unknown`.
- Derives the macro for legacy history entries that predate the new field.
- Counts only **real** visual publications, excluding local covers, so provider outages cannot flush the macro window.
- Activates exactly one guard for G.1: at most **2** `open_sandy_coast` entries within the last **5** real publications.

**`image_prompt_cy_scene.py`**
- The canonical builder and its backward-compatible wrappers accept an optional `blocked_macro_families`. A blocked macro simply continues the *existing* candidate search — weather routing, seeds, pools and cooldowns are unchanged.
- `scene_macro_family` is recorded in decision metadata and `blocked_macro_families` in the diagnostics-only `cooldown_inputs`, both assigned **after** the ordered cache key.
- Inland selection policy is unchanged; inland scenes only gain macro identity.

**`safe_test_post.py`**
- Macro blockers are derived from the restored history and passed to the same canonical `build_cyprus_visual_decision()` call as `blocked_scenes` / `blocked_compositions` / `blocked_archetypes`. No late macro correction after provider generation — one canonical decision still drives provider → dedup → diagnostics → history → receipt.
- The local fallback carries `scene_macro_family = "local_cover"` and never inherits the network macro. The production receipt gains the additive `scene_macro_family` field.

**`cyprus_visual_dedup.py`**
- A final macro diversity gate returns `scene_macro_cooldown`, evaluated **after** the existing exact / perceptual / archetype / scene / composition checks so their priorities are unchanged. The gate is hard: the caller's LRU bypass still covers only `recent_scene_family` and `recent_composition`.
- History entries gain the additive `scene_macro_family` field. Namespaces, paths and existing fields are unchanged, and legacy entries without the field keep working.

## Scope

Macro identity never replaces `visual_archetype` and never selects a scene. Unchanged: `_CYPRUS_SCENE_FAMILIES`, `_CY_COASTAL_SCENE_TEMPLATES`, `_CY_SCENE_COMPOSITIONS`, weather→scene routing and pools, selection seed/order, scene cooldown 3, composition cooldown 5, bay archetype cooldown 10, elevated archetype cooldown 6, the immediate archetype-repeat rule, LRU semantics, provider order and call limits, provider-health logic, image validation and content guard, perceptual dedup thresholds, `CYPRUS_VISUAL_PROMPT_VERSION = "cyprus_visual_v10"`, the ordered visual cache key, the local renderer version/cache payload/cache key, history and receipt namespaces and paths, text generation, post structure, workflows, editorial voice, and lunar/astro logic. Nothing was ported from KLD. `post_common.py`, `post_cy.py`, `visual_context_cy.py` and `visual_rules_cy.py` are untouched.

## Validation

All checks offline with outbound sockets blocked via the loopback proxy block.

- `python -m compileall` passed for all 7 changed files.
- Focused: `test_visual_cy` 72, `test_cyprus_visual_dedup` 19, `test_cyprus_image_fallback` 11, `test_cyprus_visual_workflow` 26.
- All 12 Cyprus PR-CI suites passed — **290** counted checks plus `test_air_cy`.
- Every suite re-run under a `socket.connect` guard: **zero** outbound connections.
- `git diff --check` passed; `.github/workflows/*` untouched; diff limited to the 7 allowed files.

Cache-identity proofs against the untouched `main` tree:

- With an empty macro policy, the Cyprus visual cache key, style name, prompt hash and cache digest are **byte-for-byte identical** across 12 mode/attempt/blocked combinations (48 compared values).
- The local informative fallback cache key (`cy_local_informative_cover_v3:5542537…`) and renderer version are unchanged.
- `scene_macro_family` and `blocked_macro_families` are asserted absent from the ordered cache key, and the style digest is still derived from `cache_key + prompt` only.

New regressions were mutation-tested and each fails when its invariant is broken: removing the dedup macro gate, letting local covers occupy the macro window, disabling macro-aware candidate search, and letting the local fallback inherit the network macro.

No Telegram, weather/air/marine/Safecast or image-provider call, no manual workflow dispatch, and no publication was run.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQzvEeLyJ1YMaEhoggbPv)_