### PR TITLE
H.1: restore daily editorial voice and make lunar facts authoritative

### DIFF
--- a/post_common.py
+++ b/post_common.py
@@ -15,7 +15,7 @@ post_common.py — VayboMeter (Кипр/универсальный).
 """
 
 from __future__ import annotations
-import os, re, json, html, asyncio, logging, math, datetime as dt, random, imghdr
+import os, re, json, html, asyncio, logging, math, datetime as dt, random, imghdr, hashlib
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Optional, Sequence, Union
 
@@ -736,8 +736,118 @@ def voc_interval_for_date(rec: dict, tz_local: str = "Asia/Nicosia"):
     return (t1, t2)
 
 
+_ASTRO_PHASE_TOKENS = {
+    "новолун": "new",
+    "полнолун": "full",
+    "убыва": "waning",
+    "растущ": "waxing",
+    "перв": "quarter",
+    "последн": "quarter",
+}
+
+_ASTRO_SIGN_SYMBOLS = "♈♉♊♋♌♍♎♏♐♑♒♓"
+
+
+def _astro_phase_token(text: str) -> str:
+    low = str(text or "").lower()
+    for needle, token in _ASTRO_PHASE_TOKENS.items():
+        if needle in low:
+            return token
+    return ""
+
+
+def astro_llm_line_contradicts_canonical(
+    line: str,
+    *,
+    phase_name: str,
+    percent: int,
+    sign_raw: str,
+    sign_sym: str,
+    voc_text: str = "",
+) -> bool:
+    """True when an LLM line states a lunar fact that differs from canonical data.
+
+    Only clearly contradictory factual claims are rejected; interpretation that adds
+    no lunar facts of its own is always kept.
+    """
+    text = str(line or "")
+    if not text.strip():
+        return False
+    low = text.lower()
+
+    canonical_phase = _astro_phase_token(phase_name)
+    line_phase = _astro_phase_token(low)
+    if canonical_phase and line_phase and line_phase != canonical_phase:
+        return True
+
+    canonical_percent = int(percent or 0)
+    for raw_value in re.findall(r"(\d{1,3})\s*%", low):
+        try:
+            claimed = int(raw_value)
+        except Exception:
+            continue
+        if canonical_percent and claimed != canonical_percent:
+            return True
+
+    canonical_sign_sym = str(sign_sym or "").strip()
+    line_symbols = {ch for ch in text if ch in _ASTRO_SIGN_SYMBOLS}
+    if canonical_sign_sym and line_symbols and line_symbols != {canonical_sign_sym}:
+        return True
+
+    canonical_sign_name = str(sign_raw or "").strip().lower()
+    if canonical_sign_name:
+        for name in _sign_names_lower():
+            if name == canonical_sign_name:
+                continue
+            if re.search(rf"(?<![а-яё]){re.escape(name[:4])}[а-яё]*", low) and name[:4] != canonical_sign_name[:4]:
+                return True
+
+    # A VoC window stated with different times contradicts the canonical interval.
+    if voc_text:
+        canonical_times = set(re.findall(r"\d{1,2}:\d{2}", str(voc_text)))
+        if canonical_times and re.search(r"\bvoc\b|без\s+курса|void", low):
+            line_times = set(re.findall(r"\d{1,2}:\d{2}", low))
+            if line_times and not (line_times & canonical_times):
+                return True
+    return False
+
+
+def _sign_names_lower() -> tuple[str, ...]:
+    return tuple(name.lower() for name in ZODIAC)
+
+
+def astro_canonical_fingerprint(
+    date_str: str,
+    phase: str,
+    percent: int,
+    sign: str,
+    voc_text: str,
+) -> str:
+    """Short deterministic digest of the canonical lunar facts for a date.
+
+    The LLM only ever interprets these facts, so its cached prose is keyed by them.
+    If the canonical facts for the same date change, the fingerprint changes and the
+    stale interpretation is no longer served.
+    """
+    payload = "|".join(
+        (
+            str(date_str or ""),
+            str(phase or ""),
+            str(int(percent or 0)),
+            str(sign or ""),
+            str(voc_text or ""),
+        )
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _astro_cache_file(date_str: str, fingerprint: str) -> Path:
+    return CACHE_DIR / f"astro_{date_str}_{fingerprint}.txt"
+
+
 def _astro_llm_bullets(date_str: str, phase: str, percent: int, sign: str, voc_text: str) -> List[str]:
-    cache_file = CACHE_DIR / f"astro_{date_str}.txt"
+    fingerprint = astro_canonical_fingerprint(date_str, phase, percent, sign, voc_text)
+    cache_file = _astro_cache_file(date_str, fingerprint)
     if cache_file.exists():
         lines = [l.strip() for l in cache_file.read_text("utf-8").splitlines() if l.strip()]
         if lines:
@@ -1159,9 +1269,23 @@ def build_astro_section(
 
     # ВАЖНО: _astro_llm_bullets уже возвращает санитизированные строки → НЕ санитизируем повторно
     llm_bullets = [x.strip() for x in llm_bullets if (x or "").strip()]
+    # The LLM is an interpretation layer only: any line that contradicts the canonical
+    # phase, illumination, sign or VoC is dropped before merging.
+    llm_bullets = [
+        line
+        for line in llm_bullets
+        if not astro_llm_line_contradicts_canonical(
+            line,
+            phase_name=phase_name,
+            percent=percent_i,
+            sign_raw=sign_raw,
+            sign_sym=sign_sym,
+            voc_text=voc_text,
+        )
+    ]
     ok_llm = len(llm_bullets) >= 3  # “считаем успехом” только полноценный блок
 
-    # ── сборка с приоритетом: LLM → (template + advice + long_desc)
+    # ── сборка: canonical facts first, LLM interpretation after
     merged: list[str] = []
 
     def _add_unique(items: list[str]) -> None:
@@ -1172,15 +1296,13 @@ def build_astro_section(
             if x not in merged:
                 merged.append(x)
 
+    # Canonical deterministic facts are added first so the final trim below can never
+    # drop them in favour of LLM prose.
+    _add_unique(template_bullets)
     if ok_llm:
         _add_unique(llm_bullets)
-        _add_unique(template_bullets)
-        _add_unique(extra_texts)
-        _add_unique(advice_bullets)
-    else:
-        _add_unique(template_bullets)
-        _add_unique(extra_texts)
-        _add_unique(advice_bullets)
+    _add_unique(extra_texts)
+    _add_unique(advice_bullets)
 
     final_bullets = merged[:5] if merged else template_bullets[:4]
 

--- a/post_common.py
+++ b/post_common.py
@@ -739,10 +739,10 @@ def voc_interval_for_date(rec: dict, tz_local: str = "Asia/Nicosia"):
 _ASTRO_PHASE_TOKENS = {
     "новолун": "new",
     "полнолун": "full",
+    "перв": "first_quarter",
+    "последн": "last_quarter",
     "убыва": "waning",
     "растущ": "waxing",
-    "перв": "quarter",
-    "последн": "quarter",
 }
 
 _ASTRO_SIGN_SYMBOLS = "♈♉♊♋♌♍♎♏♐♑♒♓"
@@ -786,7 +786,7 @@ def astro_llm_line_contradicts_canonical(
             claimed = int(raw_value)
         except Exception:
             continue
-        if canonical_percent and claimed != canonical_percent:
+        if claimed != canonical_percent:
             return True
 
     canonical_sign_sym = str(sign_sym or "").strip()
@@ -802,13 +802,15 @@ def astro_llm_line_contradicts_canonical(
             if re.search(rf"(?<![а-яё]){re.escape(name[:4])}[а-яё]*", low) and name[:4] != canonical_sign_name[:4]:
                 return True
 
-    # A VoC window stated with different times contradicts the canonical interval.
-    if voc_text:
-        canonical_times = set(re.findall(r"\d{1,2}:\d{2}", str(voc_text)))
-        if canonical_times and re.search(r"\bvoc\b|без\s+курса|void", low):
-            line_times = set(re.findall(r"\d{1,2}:\d{2}", low))
-            if line_times and not (line_times & canonical_times):
-                return True
+    # A stated VoC fact must agree with canonical presence and the exact interval.
+    voc_claim = bool(re.search(r"\bvoc\b|без\s+курса|void", low))
+    if voc_claim:
+        canonical_times = re.findall(r"\d{1,2}:\d{2}", str(voc_text or ""))
+        line_times = re.findall(r"\d{1,2}:\d{2}", low)
+        if not canonical_times:
+            return True
+        if line_times and line_times != canonical_times:
+            return True
     return False
 
 

--- a/safe_test_post.py
+++ b/safe_test_post.py
@@ -3201,9 +3201,13 @@ async def main() -> None:
         v2_raw = _apply_astro_cleanup(v2_raw)
         v2_raw = _apply_cyprus_morning_raw_context(v2_raw, raw_msg, legacy_result.text, mode)
         v2_raw = _apply_cyprus_sensor_cleanup(v2_raw)
-        v2_raw = "\n".join(_without_editorial_voice(v2_raw))
         v2_raw = _apply_score_conclusion(v2_raw)
         v2_raw = _inject_morning_smart_plan(v2_raw, mode)
+        # Editorial voice is applied exactly once, after every factual transformation
+        # and before compaction/sanitizing, so it reads the final factual text and
+        # cannot be reshaped by later factual passes. The helper strips any existing
+        # voice line first, so re-applying it never duplicates the 💬 line.
+        v2_raw = _apply_editorial_voice(v2_raw, mode)
         v2_raw = _apply_compact(v2_raw)
         final_result = sanitize_post_text(v2_raw)
         final_label = "FORMAT_V2 MESSAGE"

--- a/tools/test_editorial_voice.py
+++ b/tools/test_editorial_voice.py
@@ -192,6 +192,71 @@ def test_morning_daily_output_omits_human_line_and_keeps_facts() -> None:
     _assert_clean(text)
 
 
+LUNAR_MORNING = """<b>🌅 Кипр сегодня (27.06.2026)</b>
+🌡 Днём до 34°, ночью около 25°.
+🏭 Воздух: AQI 58 (умеренный) • PM₂.₅ 14 / PM₁₀ 31
+☀️ <b>Солнце, Луна и ритм дня</b>
+🌇 Закат сегодня: 20:05
+🌕 Полнолуние в ♑ — 100% освещённости.
+🌘 Убывающая фаза начнётся позже.
+🌙 Ритм дня спокойный.
+⚫️ VoC: 08:20–10:10.
+✅ План: вода, SPF, тень 11–16.
+#Кипр #погода #здоровье #Никосия #Тродос
+"""
+
+
+def test_editorial_voice_is_applied_once_and_is_idempotent() -> None:
+    """Re-applying the helper must never duplicate the 💬 line."""
+    once = _apply_editorial_voice(LUNAR_MORNING, "morning")
+    twice = _apply_editorial_voice(once, "morning")
+    thrice = _apply_editorial_voice(twice, "morning")
+    assert once.count("💬 По ощущениям дня:") == 1
+    assert twice.count("💬 По ощущениям дня:") == 1
+    assert thrice.count("💬 По ощущениям дня:") == 1
+    assert twice == thrice
+
+
+def test_editorial_voice_never_strips_real_lunar_lines() -> None:
+    """Lunar lines use 🌙/🌘/🌕 and must survive editorial voice handling."""
+    text = _apply_editorial_voice(LUNAR_MORNING, "morning")
+    for lunar_line in (
+        "🌕 Полнолуние в ♑ — 100% освещённости.",
+        "🌘 Убывающая фаза начнётся позже.",
+        "🌙 Ритм дня спокойный.",
+        "⚫️ VoC: 08:20–10:10.",
+    ):
+        assert lunar_line in text, lunar_line
+    # Re-applying must not erode them either.
+    again = _apply_editorial_voice(text, "morning")
+    for lunar_line in ("🌕 Полнолуние в ♑ — 100% освещённости.", "🌘 Убывающая фаза начнётся позже."):
+        assert lunar_line in again, lunar_line
+
+
+def test_editorial_voice_does_not_change_factual_values() -> None:
+    """Injecting voice must leave weather/air/lunar facts byte-identical."""
+    before = [line for line in LUNAR_MORNING.splitlines() if line.strip()]
+    after = _apply_editorial_voice(LUNAR_MORNING, "morning")
+    after_lines = [line for line in after.splitlines() if line.strip()]
+    voice_lines = [line for line in after_lines if line.startswith("💬 По ощущениям дня:")]
+    assert len(voice_lines) == 1
+    # Every original line survives unchanged, in the same relative order.
+    assert [line for line in after_lines if not line.startswith("💬")] == before
+    _assert_clean(after)
+
+
+def test_editorial_voice_keeps_hashtags_last_and_html_valid() -> None:
+    for source, mode, prefix in (
+        (LUNAR_MORNING, "morning", "💬 По ощущениям дня:"),
+        (EVENING, "evening", "💬 Настрой на завтра:"),
+    ):
+        text = _apply_editorial_voice(source, mode)
+        assert text.count(prefix) == 1
+        lines = [line for line in text.splitlines() if line.strip()]
+        assert lines[-1].startswith("#"), mode
+        _Parser().feed(text)
+
+
 def test_safe_pollen_low_does_not_select_poor_air() -> None:
     text = _apply_editorial_voice(SAFE_POLLEN_MORNING, "morning")
     line = _voice_line(text, "💬 По ощущениям дня:")
@@ -282,6 +347,10 @@ def main() -> None:
         test_evening_daily_output_omits_human_line_and_keeps_facts,
         test_evening_local_weather_variants_do_not_repeat_factual_nuance,
         test_weekly_output_contains_meaning_block_and_keeps_facts,
+        test_editorial_voice_is_applied_once_and_is_idempotent,
+        test_editorial_voice_never_strips_real_lunar_lines,
+        test_editorial_voice_does_not_change_factual_values,
+        test_editorial_voice_keeps_hashtags_last_and_html_valid,
     )
     for check in checks:
         check()

--- a/tools/test_format_v2_cy.py
+++ b/tools/test_format_v2_cy.py
@@ -842,6 +842,57 @@ def cy_workflow_morning_schedule_is_earlier() -> None:
     assert "github.event.schedule == '30 2 * * *'" not in workflow
 
 
+def cy_evening_final_publication_path_applies_editorial_voice_once() -> None:
+    """The final FORMAT_V2 path must publish exactly one evening editorial line."""
+    from html.parser import HTMLParser
+
+    import safe_test_post as safe_module
+
+    old_values = {
+        key: os.environ.get(key)
+        for key in ("EVENING_VAYBOMETER_SCORE", "FORMAT_V2_MAIN_NUANCE")
+    }
+    try:
+        os.environ.update({key: "1" for key in old_values})
+        v2 = build_evening_format_v2("Кипр", NORMAL_EVENING)
+        v2 = safe_module._inject_evening_score(v2, "evening")
+        v2 = _apply_format_v2_test_polish(v2)
+        v2 = _insert_main_nuance(v2)
+        v2 = _apply_astro_cleanup(v2)
+        v2 = _apply_cyprus_sensor_cleanup(v2)
+        v2 = safe_module._apply_editorial_voice(v2, "evening")
+        final_text = finalize_hashtags_at_end(
+            v2,
+            canonical_hashtags="#Кипр #погода #здоровье #Никосия #Тродос",
+        )
+    finally:
+        for key, value in old_values.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    assert final_text.count("💬 Настрой на завтра:") == 1
+    assert "💬 По ощущениям дня:" not in final_text
+    # Evening context is tomorrow, and the facts are untouched.
+    assert "Кипр завтра" in final_text or "завтра" in final_text
+    assert "Лимассол" in final_text
+    lines = [line for line in final_text.splitlines() if line.strip()]
+    assert lines[-1].startswith("#")
+    HTMLParser().feed(final_text)
+
+    # Re-applying the helper stays idempotent on the evening path too.
+    again = safe_module._apply_editorial_voice(final_text, "evening")
+    assert again.count("💬 Настрой на завтра:") == 1
+
+
+def cy_evening_factual_formatter_still_omits_editorial_voice() -> None:
+    """format_v2 stays a factual-only layer."""
+    text = build_evening_format_v2("Кипр", NORMAL_EVENING)
+    assert "💬 Настрой на завтра:" not in text
+    assert "💬 По ощущениям дня:" not in text
+
+
 def main() -> None:
     checks = (
         cy_morning_preserves_quake_line,
@@ -882,6 +933,8 @@ def main() -> None:
         cy_evening_current_aqi_plus_reduced_visibility_uses_point_two,
         cy_evening_explicit_forecast_aqi_can_affect_tomorrow_score,
         cy_workflow_morning_schedule_is_earlier,
+        cy_evening_final_publication_path_applies_editorial_voice_once,
+        cy_evening_factual_formatter_still_omits_editorial_voice,
     )
     for check in checks:
         check()

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -1414,7 +1414,6 @@ def cy_image_diagnostics_redacts_secrets() -> None:
         secret = "fixture-secret-token"
         try:
             os.environ["POLLINATIONS_TOKEN"] = secret
-            # The implementation writes to the standard diagnostics dir; isolate via cwd-like env is not needed here.
             path = _cy_write_image_diagnostics(
                 mode="morning",
                 target_date="2026-07-06",
@@ -2719,7 +2718,6 @@ def cy_morning_final_publication_path_applies_editorial_voice_once() -> None:
     try:
         os.environ.update({key: "1" for key in old_values})
         sanitized_legacy = sanitize_post_text(MORNING_WITH_SEA).text
-        # Same order as the production orchestration.
         v2 = build_morning_format_v2("Кипр", sanitized_legacy)
         v2 = safe_module._inject_morning_score(v2, "morning")
         v2 = safe_module._apply_format_v2_test_polish(v2)
@@ -2742,10 +2740,8 @@ def cy_morning_final_publication_path_applies_editorial_voice_once() -> None:
 
     assert final_text.count("💬 По ощущениям дня:") == 1
     assert "💬 Настрой на завтра:" not in final_text
-    # Facts survive the injection.
     assert "🌊 Море: вода 28°C" in final_text
     assert "AQI 58" in final_text
-    # Hashtags stay last and the HTML stays parseable.
     lines = [line for line in final_text.splitlines() if line.strip()]
     assert lines[-1].startswith("#")
     HTMLParser().feed(final_text)
@@ -2766,7 +2762,6 @@ def cy_final_orchestration_applies_editorial_voice_after_factual_passes() -> Non
     )
 
     voice_index = source.index("_apply_editorial_voice(v2_raw, mode)")
-    # Applied after every factual transformation...
     for factual in (
         "_apply_astro_cleanup(v2_raw)",
         "_apply_cyprus_morning_raw_context(",
@@ -2775,7 +2770,6 @@ def cy_final_orchestration_applies_editorial_voice_after_factual_passes() -> Non
         "_inject_morning_smart_plan(v2_raw, mode)",
     ):
         assert source.index(factual) < voice_index, factual
-    # ...and before compaction, sanitizing and publication.
     assert voice_index < source.index("_apply_compact(v2_raw)")
     assert voice_index < source.index("sanitize_post_text(v2_raw)")
 
@@ -2800,7 +2794,6 @@ def cy_astro_llm_cannot_override_canonical_lunar_facts() -> None:
     for line in contradictory:
         assert post_common.astro_llm_line_contradicts_canonical(line, **canonical), line
 
-    # Interpretation that states no lunar facts of its own is kept.
     for line in (
         "✅ Хороший день для спокойных дел.",
         "💚 В плюсе: восстановление и завершение.",
@@ -2832,14 +2825,11 @@ def cy_astro_llm_cache_is_keyed_by_canonical_fingerprint() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         try:
             post_common.CACHE_DIR = Path(tmp)
-            # Seed a cache entry for the original canonical facts.
             stale_path = post_common._astro_cache_file(date_str, fp_base)
             stale_path.write_text("🌕 Stale interpretation for the old facts.", encoding="utf-8")
             assert post_common._astro_llm_bullets(date_str, *base) == [
                 "🌕 Stale interpretation for the old facts."
             ]
-
-            # After the lunar facts change, the stale prose must not be served.
             os.environ["DISABLE_LLM_DAILY"] = "1"
             post_common.USE_DAILY_LLM = False
             assert post_common._astro_llm_bullets(date_str, *changed) == []
@@ -2881,8 +2871,6 @@ def cy_astro_section_drops_contradictory_llm_lines() -> None:
             "void_of_course": {"start": "10.08 08:20", "end": "10.08 10:10"},
         }
     }
-    # Three contradictory factual claims plus three fact-free interpretations, so the
-    # surviving interpretation still forms a full block after filtering.
     contradictory = [
         "🌑 Новолуние — время новых намерений.",
         "✨ 42% освещённости — Луна почти тёмная.",
@@ -2900,7 +2888,6 @@ def cy_astro_section_drops_contradictory_llm_lines() -> None:
         post_common.load_calendar = lambda *args, **kwargs: calendar
         post_common._astro_llm_bullets = lambda *args, **kwargs: list(contradictory)
         if not had_timezone:
-            # The suite stubs pendulum; build_astro_section only needs a tz handle here.
             post_common.pendulum.timezone = lambda name: name
         section = post_common.build_astro_section(
             date_local=_pendulum_date(2026, 8, 10),
@@ -2914,15 +2901,12 @@ def cy_astro_section_drops_contradictory_llm_lines() -> None:
         else:
             post_common.pendulum.timezone = old_timezone
 
-    # Canonical facts survive.
     assert "Полнолуние" in section
     assert "100%" in section
     assert "♑" in section
-    # Every contradictory factual claim is gone.
     assert "Новолуние" not in section
     assert "42%" not in section
     assert "♒" not in section
-    # Interpretation carrying no lunar facts of its own is still allowed through.
     assert "Спокойный день для рутины" in section
 
 
@@ -2938,8 +2922,6 @@ def cy_astro_canonical_facts_are_never_crowded_out_by_llm() -> None:
             "void_of_course": {"start": "10.08 08:20", "end": "10.08 10:10"},
         }
     }
-    # Five fact-free interpretation lines: none contradict, all are eligible, and they
-    # would fill the whole block if canonical facts were not added first.
     verbose = [
         "✅ Спокойный день для рутины.",
         "🌟 Хорошее время завершать начатое.",
@@ -2969,7 +2951,6 @@ def cy_astro_canonical_facts_are_never_crowded_out_by_llm() -> None:
         else:
             post_common.pendulum.timezone = old_timezone
 
-    # Canonical phase, illumination and sign all survive a verbose LLM.
     assert "Полнолуние" in section
     assert "100%" in section
     assert "♑" in section
@@ -2992,6 +2973,115 @@ def cy_astro_block_is_correct_without_llm() -> None:
     assert "🌕 Полнолуние в ♑ — 100% освещённости." in text
     assert "⚫️ VoC: 08:20–10:10." in text
     HTMLParser().feed(text)
+
+
+def cy_astro_zero_percent_is_canonical() -> None:
+    canonical = dict(
+        phase_name="Новолуние",
+        percent=0,
+        sign_raw="Рак",
+        sign_sym="♋",
+        voc_text="",
+    )
+    assert post_common_module.astro_llm_line_contradicts_canonical(
+        "✨ 15% освещённости — Луна почти тёмная.", **canonical
+    )
+    assert not post_common_module.astro_llm_line_contradicts_canonical(
+        "🌑 Новолуние в ♋ — 0% освещённости.", **canonical
+    )
+
+
+def cy_astro_quarter_phases_are_distinct() -> None:
+    common = dict(percent=50, sign_raw="Рак", sign_sym="♋", voc_text="")
+    assert post_common_module.astro_llm_line_contradicts_canonical(
+        "🌗 Последняя четверть — время завершать дела.",
+        phase_name="Первая четверть",
+        **common,
+    )
+    assert post_common_module.astro_llm_line_contradicts_canonical(
+        "🌓 Первая четверть — пора набирать темп.",
+        phase_name="Последняя четверть",
+        **common,
+    )
+    assert not post_common_module.astro_llm_line_contradicts_canonical(
+        "🌓 Первая четверть — сохраняй спокойный темп.",
+        phase_name="Первая четверть",
+        **common,
+    )
+
+
+def cy_astro_voc_interval_requires_exact_match() -> None:
+    canonical = dict(
+        phase_name="Полнолуние",
+        percent=100,
+        sign_raw="Козерог",
+        sign_sym="♑",
+        voc_text="08:20–10:10",
+    )
+    assert post_common_module.astro_llm_line_contradicts_canonical(
+        "⚫️ VoC: 08:20–11:30 — без стартов.", **canonical
+    )
+    assert not post_common_module.astro_llm_line_contradicts_canonical(
+        "⚫️ VoC: 08:20–10:10 — без стартов.", **canonical
+    )
+
+    # Behavioral path: a partially matching interval must be filtered before merge.
+    calendar = {
+        "2026-08-10": {
+            "phase_name": "Полнолуние",
+            "percent": 100,
+            "sign": "Козерог",
+            "void_of_course": {"start": "10.08 08:20", "end": "10.08 10:10"},
+        }
+    }
+    llm_lines = [
+        "⚫️ VoC: 08:20–11:30 — без стартов.",
+        "✅ Спокойный день для рутины.",
+        "🌟 Хорошее время завершать начатое.",
+        "🧭 План дня держи простым.",
+    ]
+    old_calendar = post_common_module.load_calendar
+    old_bullets = post_common_module._astro_llm_bullets
+    had_timezone = hasattr(post_common_module.pendulum, "timezone")
+    old_timezone = getattr(post_common_module.pendulum, "timezone", None)
+    try:
+        post_common_module.load_calendar = lambda *args, **kwargs: calendar
+        post_common_module._astro_llm_bullets = lambda *args, **kwargs: list(llm_lines)
+        if not had_timezone:
+            post_common_module.pendulum.timezone = lambda name: name
+        section = post_common_module.build_astro_section(
+            date_local=_pendulum_date(2026, 8, 10),
+            tz_local="Asia/Nicosia",
+        )
+    finally:
+        post_common_module.load_calendar = old_calendar
+        post_common_module._astro_llm_bullets = old_bullets
+        if not had_timezone:
+            delattr(post_common_module.pendulum, "timezone")
+        else:
+            post_common_module.pendulum.timezone = old_timezone
+    assert "11:30" not in section
+    assert "08:20–10:10" in section
+    assert "Спокойный день для рутины" in section
+
+
+def cy_astro_absent_voc_cannot_be_invented_by_llm() -> None:
+    canonical = dict(
+        phase_name="Полнолуние",
+        percent=100,
+        sign_raw="Козерог",
+        sign_sym="♑",
+        voc_text="",
+    )
+    for fake in (
+        "⚫️ VoC: 12:00–13:00 — без стартов.",
+        "⚫️ Луна без курса 12:00–13:00 — отложи старты.",
+        "⚫️ Void of Course 12:00–13:00.",
+    ):
+        assert post_common_module.astro_llm_line_contradicts_canonical(fake, **canonical), fake
+    assert not post_common_module.astro_llm_line_contradicts_canonical(
+        "✅ Спокойный день для рутины.", **canonical
+    )
 
 
 def main() -> None:
@@ -3071,6 +3161,10 @@ def main() -> None:
         cy_astro_section_drops_contradictory_llm_lines,
         cy_astro_canonical_facts_are_never_crowded_out_by_llm,
         cy_astro_block_is_correct_without_llm,
+        cy_astro_zero_percent_is_canonical,
+        cy_astro_quarter_phases_are_distinct,
+        cy_astro_voc_interval_requires_exact_match,
+        cy_astro_absent_voc_cannot_be_invented_by_llm,
     )
     for check in checks:
         check()

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -1874,18 +1874,15 @@ def cy_image_repeated_pollinations_switches_backend_and_sends_receipt() -> None:
                 sys.modules.pop("world_en.imagegen", None)
             else:
                 sys.modules["world_en.imagegen"] = imagegen_old
-            if old_img_dir is None:
-                os.environ.pop("CY_SAFE_IMAGE_DIR", None)
-            else:
-                os.environ["CY_SAFE_IMAGE_DIR"] = old_img_dir
-            if old_min is None:
-                os.environ.pop("CY_IMG_MIN_BYTES", None)
-            else:
-                os.environ["CY_IMG_MIN_BYTES"] = old_min
-            if old_channel is None:
-                os.environ.pop("CHANNEL_ID", None)
-            else:
-                os.environ["CHANNEL_ID"] = old_channel
+            for key, value in (
+                ("CY_SAFE_IMAGE_DIR", old_img_dir),
+                ("CY_IMG_MIN_BYTES", old_min),
+                ("CHANNEL_ID", old_channel),
+            ):
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
         return result, excluded_seen, photo_calls
 
     def _case(tmp: Path) -> None:
@@ -3042,11 +3039,15 @@ def cy_astro_voc_interval_requires_exact_match() -> None:
     ]
     old_calendar = post_common_module.load_calendar
     old_bullets = post_common_module._astro_llm_bullets
+    old_voc_interval = post_common_module.voc_interval_for_date
     had_timezone = hasattr(post_common_module.pendulum, "timezone")
     old_timezone = getattr(post_common_module.pendulum, "timezone", None)
+    voc_start = types.SimpleNamespace(format=lambda _pattern: "08:20")
+    voc_end = types.SimpleNamespace(format=lambda _pattern: "10:10")
     try:
         post_common_module.load_calendar = lambda *args, **kwargs: calendar
         post_common_module._astro_llm_bullets = lambda *args, **kwargs: list(llm_lines)
+        post_common_module.voc_interval_for_date = lambda *args, **kwargs: (voc_start, voc_end)
         if not had_timezone:
             post_common_module.pendulum.timezone = lambda name: name
         section = post_common_module.build_astro_section(
@@ -3056,6 +3057,7 @@ def cy_astro_voc_interval_requires_exact_match() -> None:
     finally:
         post_common_module.load_calendar = old_calendar
         post_common_module._astro_llm_bullets = old_bullets
+        post_common_module.voc_interval_for_date = old_voc_interval
         if not had_timezone:
             delattr(post_common_module.pendulum, "timezone")
         else:

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -1874,15 +1874,18 @@ def cy_image_repeated_pollinations_switches_backend_and_sends_receipt() -> None:
                 sys.modules.pop("world_en.imagegen", None)
             else:
                 sys.modules["world_en.imagegen"] = imagegen_old
-            for key, value in (
-                ("CY_SAFE_IMAGE_DIR", old_img_dir),
-                ("CY_IMG_MIN_BYTES", old_min),
-                ("CHANNEL_ID", old_channel),
-            ):
-                if value is None:
-                    os.environ.pop(key, None)
-                else:
-                    os.environ[key] = value
+            if old_img_dir is None:
+                os.environ.pop("CY_SAFE_IMAGE_DIR", None)
+            else:
+                os.environ["CY_SAFE_IMAGE_DIR"] = old_img_dir
+            if old_min is None:
+                os.environ.pop("CY_IMG_MIN_BYTES", None)
+            else:
+                os.environ["CY_IMG_MIN_BYTES"] = old_min
+            if old_channel is None:
+                os.environ.pop("CHANNEL_ID", None)
+            else:
+                os.environ["CHANNEL_ID"] = old_channel
         return result, excluded_seen, photo_calls
 
     def _case(tmp: Path) -> None:

--- a/tools/test_format_v2_morning_cy.py
+++ b/tools/test_format_v2_morning_cy.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import types
 from datetime import date
+from html.parser import HTMLParser
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -2707,6 +2708,292 @@ def cy_morning_safe_production_polish_keeps_fog_actions() -> None:
     assert "✅ План: утром снизить скорость и увеличить дистанцию; после прояснения — вода, SPF и тень." in final
 
 
+def cy_morning_final_publication_path_applies_editorial_voice_once() -> None:
+    """The final FORMAT_V2 path must publish exactly one morning editorial line."""
+    import safe_test_post as safe_module
+
+    old_values = {
+        key: os.environ.get(key)
+        for key in ("MORNING_VAYBOMETER_SCORE", "FORMAT_V2_MAIN_NUANCE", "MORNING_SMART_PLAN")
+    }
+    try:
+        os.environ.update({key: "1" for key in old_values})
+        sanitized_legacy = sanitize_post_text(MORNING_WITH_SEA).text
+        # Same order as the production orchestration.
+        v2 = build_morning_format_v2("Кипр", sanitized_legacy)
+        v2 = safe_module._inject_morning_score(v2, "morning")
+        v2 = safe_module._apply_format_v2_test_polish(v2)
+        v2 = _insert_main_nuance(v2)
+        v2 = _apply_astro_cleanup(v2)
+        v2 = _apply_cyprus_sensor_cleanup(v2)
+        v2 = safe_module._inject_morning_smart_plan(v2, "morning")
+        v2 = safe_module._apply_editorial_voice(v2, "morning")
+        final_text = sanitize_post_text(v2).text
+        final_text = finalize_hashtags_at_end(
+            final_text,
+            canonical_hashtags="#Кипр #погода #здоровье #Никосия #Тродос",
+        )
+    finally:
+        for key, value in old_values.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    assert final_text.count("💬 По ощущениям дня:") == 1
+    assert "💬 Настрой на завтра:" not in final_text
+    # Facts survive the injection.
+    assert "🌊 Море: вода 28°C" in final_text
+    assert "AQI 58" in final_text
+    # Hashtags stay last and the HTML stays parseable.
+    lines = [line for line in final_text.splitlines() if line.strip()]
+    assert lines[-1].startswith("#")
+    HTMLParser().feed(final_text)
+
+
+def cy_final_orchestration_applies_editorial_voice_after_factual_passes() -> None:
+    """Guard the orchestration order itself: voice is applied, not stripped."""
+    import inspect
+
+    import safe_test_post as safe_module
+
+    source = inspect.getsource(safe_module.main)
+    assert "_apply_editorial_voice(v2_raw, mode)" in source, (
+        "final FORMAT_V2 orchestration no longer applies the editorial voice"
+    )
+    assert '"\\n".join(_without_editorial_voice(v2_raw))' not in source, (
+        "final FORMAT_V2 orchestration still strips the editorial voice"
+    )
+
+    voice_index = source.index("_apply_editorial_voice(v2_raw, mode)")
+    # Applied after every factual transformation...
+    for factual in (
+        "_apply_astro_cleanup(v2_raw)",
+        "_apply_cyprus_morning_raw_context(",
+        "_apply_cyprus_sensor_cleanup(v2_raw)",
+        "_apply_score_conclusion(v2_raw)",
+        "_inject_morning_smart_plan(v2_raw, mode)",
+    ):
+        assert source.index(factual) < voice_index, factual
+    # ...and before compaction, sanitizing and publication.
+    assert voice_index < source.index("_apply_compact(v2_raw)")
+    assert voice_index < source.index("sanitize_post_text(v2_raw)")
+
+
+def cy_astro_llm_cannot_override_canonical_lunar_facts() -> None:
+    """Contradictory or stale LLM prose must never replace canonical lunar facts."""
+    import post_common
+
+    canonical = dict(
+        phase_name="Полнолуние",
+        percent=100,
+        sign_raw="Козерог",
+        sign_sym="♑",
+        voc_text="08:20–10:10",
+    )
+    contradictory = (
+        "🌑 Новолуние — время новых намерений.",
+        "✨ 42% освещённости — Луна тусклая.",
+        "🌙 Луна в ♒ — идеи и общение.",
+        "⚫️ VoC: 14:00–15:30 — без стартов.",
+    )
+    for line in contradictory:
+        assert post_common.astro_llm_line_contradicts_canonical(line, **canonical), line
+
+    # Interpretation that states no lunar facts of its own is kept.
+    for line in (
+        "✅ Хороший день для спокойных дел.",
+        "💚 В плюсе: восстановление и завершение.",
+        "🌕 Полнолуние в ♑ — 100% освещённости.",
+        "⚫️ VoC: 08:20–10:10.",
+    ):
+        assert not post_common.astro_llm_line_contradicts_canonical(line, **canonical), line
+
+
+def cy_astro_llm_cache_is_keyed_by_canonical_fingerprint() -> None:
+    """A cache written for different lunar facts must not be reused for the same date."""
+    import post_common
+
+    date_str = "10.08.2026"
+    base = ("Полнолуние", 100, "Козерог", "08:20–10:10")
+    changed = ("Убывающая Луна", 92, "Козерог", "08:20–10:10")
+
+    fp_base = post_common.astro_canonical_fingerprint(date_str, *base)
+    fp_same = post_common.astro_canonical_fingerprint(date_str, *base)
+    fp_changed = post_common.astro_canonical_fingerprint(date_str, *changed)
+    assert fp_base == fp_same
+    assert fp_base != fp_changed
+    assert post_common._astro_cache_file(date_str, fp_base) != post_common._astro_cache_file(
+        date_str, fp_changed
+    )
+
+    old_cache_dir = post_common.CACHE_DIR
+    old_llm = os.environ.get("DISABLE_LLM_DAILY")
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            post_common.CACHE_DIR = Path(tmp)
+            # Seed a cache entry for the original canonical facts.
+            stale_path = post_common._astro_cache_file(date_str, fp_base)
+            stale_path.write_text("🌕 Stale interpretation for the old facts.", encoding="utf-8")
+            assert post_common._astro_llm_bullets(date_str, *base) == [
+                "🌕 Stale interpretation for the old facts."
+            ]
+
+            # After the lunar facts change, the stale prose must not be served.
+            os.environ["DISABLE_LLM_DAILY"] = "1"
+            post_common.USE_DAILY_LLM = False
+            assert post_common._astro_llm_bullets(date_str, *changed) == []
+        finally:
+            post_common.CACHE_DIR = old_cache_dir
+            post_common.USE_DAILY_LLM = True
+            if old_llm is None:
+                os.environ.pop("DISABLE_LLM_DAILY", None)
+            else:
+                os.environ["DISABLE_LLM_DAILY"] = old_llm
+
+
+def _pendulum_date(year: int, month: int, day: int):
+    """Minimal date object with the attributes build_astro_section uses."""
+    import datetime as _dt
+
+    class _D(_dt.date):
+        def add(self, days: int = 0):
+            shifted = _dt.date(self.year, self.month, self.day) + _dt.timedelta(days=days)
+            return _D(shifted.year, shifted.month, shifted.day)
+
+        def format(self, fmt: str) -> str:
+            if fmt == "YYYY-MM-DD":
+                return f"{self.year}-{self.month:02d}-{self.day:02d}"
+            return f"{self.day:02d}.{self.month:02d}.{self.year}"
+
+    return _D(year, month, day)
+
+
+def cy_astro_section_drops_contradictory_llm_lines() -> None:
+    """End-to-end: contradictory LLM prose must not reach the rendered astro block."""
+    import post_common
+
+    calendar = {
+        "2026-08-10": {
+            "phase_name": "Полнолуние",
+            "percent": 100,
+            "sign": "Козерог",
+            "void_of_course": {"start": "10.08 08:20", "end": "10.08 10:10"},
+        }
+    }
+    # Three contradictory factual claims plus three fact-free interpretations, so the
+    # surviving interpretation still forms a full block after filtering.
+    contradictory = [
+        "🌑 Новолуние — время новых намерений.",
+        "✨ 42% освещённости — Луна почти тёмная.",
+        "🌙 Луна в ♒ — идеи и лёгкое общение.",
+        "✅ Спокойный день для рутины.",
+        "🌟 Хорошее время завершать начатое.",
+        "🧭 План дня держи простым.",
+    ]
+
+    old_calendar = post_common.load_calendar
+    old_bullets = post_common._astro_llm_bullets
+    had_timezone = hasattr(post_common.pendulum, "timezone")
+    old_timezone = getattr(post_common.pendulum, "timezone", None)
+    try:
+        post_common.load_calendar = lambda *args, **kwargs: calendar
+        post_common._astro_llm_bullets = lambda *args, **kwargs: list(contradictory)
+        if not had_timezone:
+            # The suite stubs pendulum; build_astro_section only needs a tz handle here.
+            post_common.pendulum.timezone = lambda name: name
+        section = post_common.build_astro_section(
+            date_local=_pendulum_date(2026, 8, 10),
+            tz_local="Asia/Nicosia",
+        )
+    finally:
+        post_common.load_calendar = old_calendar
+        post_common._astro_llm_bullets = old_bullets
+        if not had_timezone:
+            delattr(post_common.pendulum, "timezone")
+        else:
+            post_common.pendulum.timezone = old_timezone
+
+    # Canonical facts survive.
+    assert "Полнолуние" in section
+    assert "100%" in section
+    assert "♑" in section
+    # Every contradictory factual claim is gone.
+    assert "Новолуние" not in section
+    assert "42%" not in section
+    assert "♒" not in section
+    # Interpretation carrying no lunar facts of its own is still allowed through.
+    assert "Спокойный день для рутины" in section
+
+
+def cy_astro_canonical_facts_are_never_crowded_out_by_llm() -> None:
+    """A verbose LLM must not push canonical phase/illumination out of the block."""
+    import post_common
+
+    calendar = {
+        "2026-08-10": {
+            "phase_name": "Полнолуние",
+            "percent": 100,
+            "sign": "Козерог",
+            "void_of_course": {"start": "10.08 08:20", "end": "10.08 10:10"},
+        }
+    }
+    # Five fact-free interpretation lines: none contradict, all are eligible, and they
+    # would fill the whole block if canonical facts were not added first.
+    verbose = [
+        "✅ Спокойный день для рутины.",
+        "🌟 Хорошее время завершать начатое.",
+        "🧭 План дня держи простым.",
+        "🫧 Больше пауз и воды.",
+        "📋 Дела лучше делать по одному.",
+    ]
+
+    old_calendar = post_common.load_calendar
+    old_bullets = post_common._astro_llm_bullets
+    had_timezone = hasattr(post_common.pendulum, "timezone")
+    old_timezone = getattr(post_common.pendulum, "timezone", None)
+    try:
+        post_common.load_calendar = lambda *args, **kwargs: calendar
+        post_common._astro_llm_bullets = lambda *args, **kwargs: list(verbose)
+        if not had_timezone:
+            post_common.pendulum.timezone = lambda name: name
+        section = post_common.build_astro_section(
+            date_local=_pendulum_date(2026, 8, 10),
+            tz_local="Asia/Nicosia",
+        )
+    finally:
+        post_common.load_calendar = old_calendar
+        post_common._astro_llm_bullets = old_bullets
+        if not had_timezone:
+            delattr(post_common.pendulum, "timezone")
+        else:
+            post_common.pendulum.timezone = old_timezone
+
+    # Canonical phase, illumination and sign all survive a verbose LLM.
+    assert "Полнолуние" in section
+    assert "100%" in section
+    assert "♑" in section
+
+
+def cy_astro_block_is_correct_without_llm() -> None:
+    """With the LLM disabled the deterministic astro block still carries the facts."""
+    import post_common
+
+    old_llm_flag = post_common.USE_DAILY_LLM
+    old_bullets = post_common._astro_llm_bullets
+    try:
+        post_common.USE_DAILY_LLM = False
+        post_common._astro_llm_bullets = lambda *args, **kwargs: []
+        text = build_morning_format_v2("Кипр", MORNING_FULL_MOON)
+    finally:
+        post_common.USE_DAILY_LLM = old_llm_flag
+        post_common._astro_llm_bullets = old_bullets
+
+    assert "🌕 Полнолуние в ♑ — 100% освещённости." in text
+    assert "⚫️ VoC: 08:20–10:10." in text
+    HTMLParser().feed(text)
+
+
 def main() -> None:
     checks = (
         cy_weather_attempts_request_only_sea_level_pressure,
@@ -2777,6 +3064,13 @@ def main() -> None:
         cy_evening_does_not_use_current_aqi_for_tomorrow_visibility,
         cy_evening_preserves_only_tomorrow_morning_visibility,
         cy_morning_safe_production_polish_keeps_fog_actions,
+        cy_morning_final_publication_path_applies_editorial_voice_once,
+        cy_final_orchestration_applies_editorial_voice_after_factual_passes,
+        cy_astro_llm_cannot_override_canonical_lunar_facts,
+        cy_astro_llm_cache_is_keyed_by_canonical_fingerprint,
+        cy_astro_section_drops_contradictory_llm_lines,
+        cy_astro_canonical_facts_are_never_crowded_out_by_llm,
+        cy_astro_block_is_correct_without_llm,
     )
     for check in checks:
         check()


### PR DESCRIPTION
## What changed

Two confirmed audit findings, fixed with minimal changes.

### H.1a — the editorial voice never reached the published post

The final FORMAT_V2 orchestration called `_without_editorial_voice()` and **dropped** the line that `_apply_editorial_voice()` exists to add, so no published post ever carried the daily human line.

It is now applied **exactly once**, after every factual transformation (FORMAT_V2 build → factual cleanup → score/conclusion → astro cleanup → raw/sensor corrections → smart plan) and **before** compaction, sanitizing and publication.

- `format_v2.py` stays a factual-only layer and is untouched — the voice is not added inside `build_morning_format_v2()` or `build_evening_format_v2()`.
- The helper strips any existing voice line first, so re-applying it never duplicates the `💬` line.
- Morning publishes `💬 По ощущениям дня: …`, evening publishes `💬 Настрой на завтра: …`.
- Existing phrase banks and tone are unchanged.

### H.1b — canonical lunar/astro facts now take absolute priority

The LLM is an interpretation layer only, but two paths let it override the facts:

- **Stale cache.** The astro LLM cache was keyed by date alone (`astro_{date}.txt`), so prose written for one set of lunar facts was still served after those facts changed for the same date. The key now includes a fingerprint of the canonical inputs (date, phase, percent, sign, VoC), so a changed fact means a changed key and no stale reuse.
- **Crowding out and contradiction.** LLM lines were merged *ahead* of the canonical template lines, and the final `[:5]` trim could drop phase, illumination or sign in favour of LLM prose. Canonical facts are now added first, and any LLM line stating a lunar fact that differs from the canonical phase, illumination, sign or VoC is dropped before merging. Interpretation stating no lunar facts of its own is kept unchanged.

Lunar calculations, today/tomorrow routing and `ASTRO_OFFSET` semantics are unchanged, and the LLM never becomes a source of astronomy facts.

## Scope

Changed files: `safe_test_post.py`, `post_common.py`, `tools/test_editorial_voice.py`, `tools/test_format_v2_cy.py`, `tools/test_format_v2_morning_cy.py` — exactly the allowed set.

Untouched: `format_v2.py`, `editorial_voice.py`, the visual pipeline, image generation, weather/air/Safecast logic, workflows, Telegram routing, delivery receipts, publication architecture and provider order. The only cache-namespace change is the astro LLM cache filename inside `post_common.py`, as permitted.

## Validation

All offline, with a loopback proxy block and `DISABLE_LLM_DAILY=1`.

- `python -m py_compile` passed for all 5 changed files.
- `tools/test_editorial_voice.py` 13, `tools/test_format_v2_cy.py` 40, `tools/test_format_v2_morning_cy.py` 75.
- Full local suite: **all 17** `tools/test_*.py` suites passed.
- Every suite re-run under a `socket.connect` guard: **zero** outbound connections. All LLM use in tests is stubbed — no OpenAI, Gemini, Groq, Telegram or image-provider call.
- `git diff --check` passed.

Regressions cover the required points: one editorial line in the final morning and evening paths, the factual formatters still omitting the voice, idempotent re-application, facts untouched by injection, real `🌙`/`🌘`/`🌕` lunar lines never stripped, hashtags last and HTML valid, a static guard on the orchestration order, contradictory LLM lines dropped end-to-end, canonical facts never crowded out by a verbose LLM, fingerprint-keyed cache rejecting stale prose, and a correct deterministic block with the LLM disabled.

Each fix was mutation-tested: restoring the old strip, reverting the cache key to date-only, disabling the contradiction filter, and putting LLM lines ahead of canonical facts each make a test fail.

No manual workflow dispatch, Actions rerun, publication or merge was performed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019tQzvEeLyJ1YMaEhoggbPv)_