### PR TITLE
fix: collapse all-green Cyprus city air

### DIFF
--- a/format_v2.py
+++ b/format_v2.py
@@ -666,9 +666,12 @@ def _clean_city_air_line(line: str) -> str:
     value_re = r"\d+(?:[\.,]\d+)?"
     chunks: list[str] = []
     markers: list[str] = []
+    parsed_cities: set[str] = set()
+    required_all_green_cities = {"никосия", "лимассол", "ларнака", "пафос", "айя-напа"}
     token_re = rf"({city_re})\s+([🟢🟡🟠🔴])(?P<tail>.*?)(?=(?:\s*·\s*|\s+{city_re}\s+[🟢🟡🟠🔴]|$))"
     for m in re.finditer(token_re, body, flags=re.I):
         city, marker = m.group(1), m.group(2)
+        parsed_cities.add(city.casefold())
         markers.append(marker)
         tail = (m.group("tail") or "").strip()
         pollutant = ""
@@ -682,7 +685,7 @@ def _clean_city_air_line(line: str) -> str:
                 pollutant = f"{pollutant} {value.replace(',', '.')}"
         chunks.append(f"{city} {marker}" + (f" ({pollutant})" if pollutant else ""))
     if chunks:
-        if markers and all(marker == "🟢" for marker in markers):
+        if required_all_green_cities.issubset(parsed_cities) and markers and all(marker == "🟢" for marker in markers):
             return "🏭 Воздух по городам: везде 🟢"
         return "🏭 Воздух по городам: " + " · ".join(chunks[:6])
     return "🏭 Воздух по городам: " + body

--- a/format_v2.py
+++ b/format_v2.py
@@ -665,9 +665,11 @@ def _clean_city_air_line(line: str) -> str:
     pollutant_re = r"PM₂\.₅|PM2\.?5|PM₁₀|PM10|NO₂|NO2|O₃|O3|SO₂|SO2|CO"
     value_re = r"\d+(?:[\.,]\d+)?"
     chunks: list[str] = []
+    markers: list[str] = []
     token_re = rf"({city_re})\s+([🟢🟡🟠🔴])(?P<tail>.*?)(?=(?:\s*·\s*|\s+{city_re}\s+[🟢🟡🟠🔴]|$))"
     for m in re.finditer(token_re, body, flags=re.I):
         city, marker = m.group(1), m.group(2)
+        markers.append(marker)
         tail = (m.group("tail") or "").strip()
         pollutant = ""
         pollutant_match = re.search(rf"({pollutant_re})(?:\s*({value_re}))?", tail, flags=re.I)
@@ -680,6 +682,8 @@ def _clean_city_air_line(line: str) -> str:
                 pollutant = f"{pollutant} {value.replace(',', '.')}"
         chunks.append(f"{city} {marker}" + (f" ({pollutant})" if pollutant else ""))
     if chunks:
+        if markers and all(marker == "🟢" for marker in markers):
+            return "🏭 Воздух по городам: везде 🟢"
         return "🏭 Воздух по городам: " + " · ".join(chunks[:6])
     return "🏭 Воздух по городам: " + body
 

--- a/tools/test_format_v2_cy.py
+++ b/tools/test_format_v2_cy.py
@@ -322,6 +322,19 @@ CITY_AIR_BROKEN_EVENING = """<b>🌅 Кипр: погода на завтра (2
 #Кипр #погода #здоровье #Никосия #Тродос
 """
 
+ALL_GREEN_CITY_AIR_EVENING = """<b>🌅 Кипр: погода на завтра (27.06.2026)</b>
+✨ VayboMeter завтра: 7.0/10 — обычный день.
+🏖 <b>Морские города</b>
+Ларнака: 29/23 °C • ясно
+———
+🏭 Воздух: AQI 52 (умеренный) • PM₂.₅ 11 / PM₁₀ 17
+🏭 Воздух по городам: Никосия 🟢 · Лимассол 🟢 · Ларнака 🟢 · Пафос 🟢 · Айя-Напа 🟢
+🌅 Рассвет завтра: 05:37
+🌕 Полнолуние в ♐ — 96% освещённости.
+💚 В плюсе: планы.
+#Кипр #погода #здоровье #Никосия #Тродос
+"""
+
 
 GENERIC_UV_WARNING_EVENING = """<b>🌅 Кипр: погода на завтра (27.06.2026)</b>
 ✨ VayboMeter завтра: 8.1/10 — хорошо для обычных дел.
@@ -602,11 +615,21 @@ def cy_evening_surf_with_valid_wave_is_cautiously_positive() -> None:
     assert "🏄 Серф: есть рабочие окна по волне; проверить конкретный спот." in text
 
 
+def cy_evening_all_green_city_air_collapses_to_summary() -> None:
+    text = _safe_test_evening_pipeline(ALL_GREEN_CITY_AIR_EVENING)
+    assert "🏭 Воздух: AQI 52 (умеренный) • PM₂.₅ 11 / PM₁₀ 17" in text
+    assert "🏭 Воздух по городам: везде 🟢" in text
+    assert "Никосия 🟢" not in text
+    assert "Лимассол 🟢" not in text
+    assert text.count("🏭 Воздух по городам:") == 1
+
+
 def cy_evening_city_air_line_is_compact_and_parenthesized() -> None:
     text = _safe_test_evening_pipeline(CITY_AIR_BROKEN_EVENING)
     expected = "🏭 Воздух по городам: Никосия 🟢 · Лимассол 🟢 · Ларнака 🟡 (PM₂.₅ 18) · Пафос 🟠 (PM₂.₅ 28) · Айя-Напа 🟢"
     assert expected in text
     assert "Ларнака 🟡 PM₂.₅ 18 Пафос" not in text
+    assert "🏭 Воздух по городам: везде 🟢" not in text
     assert text.count("🏭 Воздух по городам:") == 1
 
 
@@ -971,6 +994,7 @@ def main() -> None:
         cy_evening_unstructured_dust_text_does_not_create_air_warning,
         cy_evening_surf_without_wave_is_not_excellent,
         cy_evening_surf_with_valid_wave_is_cautiously_positive,
+        cy_evening_all_green_city_air_collapses_to_summary,
         cy_evening_city_air_line_is_compact_and_parenthesized,
         cy_evening_integrated_guidance_is_not_repetitive,
         cy_evening_generic_warning_does_not_trigger_storm,

--- a/tools/test_format_v2_cy.py
+++ b/tools/test_format_v2_cy.py
@@ -624,6 +624,27 @@ def cy_evening_all_green_city_air_collapses_to_summary() -> None:
     assert text.count("🏭 Воздух по городам:") == 1
 
 
+def cy_evening_single_green_city_does_not_claim_everywhere() -> None:
+    source = ALL_GREEN_CITY_AIR_EVENING.replace(
+        "🏭 Воздух по городам: Никосия 🟢 · Лимассол 🟢 · Ларнака 🟢 · Пафос 🟢 · Айя-Напа 🟢",
+        "🏭 Воздух по городам: Никосия 🟢",
+    )
+    text = _safe_test_evening_pipeline(source)
+    assert "🏭 Воздух по городам: везде 🟢" not in text
+    assert "🏭 Воздух по городам: Никосия 🟢" in text
+
+
+def cy_evening_incomplete_five_city_air_does_not_claim_everywhere() -> None:
+    expected = "🏭 Воздух по городам: Никосия 🟢 · Лимассол 🟢 · Ларнака 🟢 · Айя-Напа 🟢 · Тродос 🟢"
+    source = ALL_GREEN_CITY_AIR_EVENING.replace(
+        "🏭 Воздух по городам: Никосия 🟢 · Лимассол 🟢 · Ларнака 🟢 · Пафос 🟢 · Айя-Напа 🟢",
+        expected,
+    )
+    text = _safe_test_evening_pipeline(source)
+    assert "🏭 Воздух по городам: везде 🟢" not in text
+    assert expected in text
+
+
 def cy_evening_city_air_line_is_compact_and_parenthesized() -> None:
     text = _safe_test_evening_pipeline(CITY_AIR_BROKEN_EVENING)
     expected = "🏭 Воздух по городам: Никосия 🟢 · Лимассол 🟢 · Ларнака 🟡 (PM₂.₅ 18) · Пафос 🟠 (PM₂.₅ 28) · Айя-Напа 🟢"
@@ -995,6 +1016,8 @@ def main() -> None:
         cy_evening_surf_without_wave_is_not_excellent,
         cy_evening_surf_with_valid_wave_is_cautiously_positive,
         cy_evening_all_green_city_air_collapses_to_summary,
+        cy_evening_single_green_city_does_not_claim_everywhere,
+        cy_evening_incomplete_five_city_air_does_not_claim_everywhere,
         cy_evening_city_air_line_is_compact_and_parenthesized,
         cy_evening_integrated_guidance_is_not_repetitive,
         cy_evening_generic_warning_does_not_trigger_storm,


### PR DESCRIPTION
## Problem

When every recognized Cyprus city-air marker is green, FORMAT_V2 still enumerates every city individually. That repeats equivalent information without adding a city-specific warning.

## Change

- collapse an all-green recognized city-air list to exactly `🏭 Воздух по городам: везде 🟢`;
- preserve the existing city enumeration and pollutant details whenever any recognized city is non-green;
- keep the main `🏭 Воздух: AQI ... PM₂.₅ ... PM₁₀ ...` line unchanged;
- add focused regressions for the all-green case and mixed-marker preservation.

Air-quality sources and semantics, Safecast, weather, publication, and all other FORMAT_V2 blocks are unchanged.

## Scope

Changed files are exactly:

- `format_v2.py`
- `tools/test_format_v2_cy.py`

## Validation

The focused regression cases are included in the existing offline Cyprus FORMAT_V2 test suite. Complete repository-native validation is left to the automatic PR CI. No workflow was manually dispatched, rerun, retried or cancelled, and no publication or operational external API call was made for this change.